### PR TITLE
Explicit path flags

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -79,12 +79,12 @@ func AddExecute(c *Cmd) error {
 	specifiedConfig := ExtractSubCmdValue(Config, c.SubCmds)
 	var configPath string
 	var err error
-	if specifiedConfig == "default" {
-		configPath, err = config.DefaultConfigPath()
-	} else if specifiedConfig == "" {
+	if specifiedConfig == nil {
 		configPath, err = config.UsedConfig()
+	} else if *specifiedConfig == "default" {
+		configPath, err = config.DefaultConfigPath()
 	} else {
-		configPath, err = filepath.Abs(specifiedConfig)
+		configPath, err = filepath.Abs(*specifiedConfig)
 	}
 	if err != nil {
 		return fmt.Errorf("Failed to get config path: %s", err)

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -60,12 +60,12 @@ func EditExecute(c *Cmd) error {
 	specifiedConfig := ExtractSubCmdValue(Config, c.SubCmds)
 	var configPath string
 	var err error
-	if specifiedConfig == "default" {
-		configPath, err = config.DefaultConfigPath()
-	} else if specifiedConfig == "" {
+	if specifiedConfig == nil {
 		configPath, err = config.UsedConfig()
+	} else if *specifiedConfig == "default" {
+		configPath, err = config.DefaultConfigPath()
 	} else {
-		configPath, err = filepath.Abs(specifiedConfig)
+		configPath, err = filepath.Abs(*specifiedConfig)
 	}
 	if err != nil {
 		return fmt.Errorf("Failed to get config path: %s", err)

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -50,12 +50,12 @@ func RemoveExecute(c *Cmd) error {
 	specifiedConfig := ExtractSubCmdValue(Config, c.SubCmds)
 	var configPath string
 	var err error
-	if specifiedConfig == "default" {
-		configPath, err = config.DefaultConfigPath()
-	} else if specifiedConfig == "" {
+	if specifiedConfig == nil {
 		configPath, err = config.UsedConfig()
+	} else if *specifiedConfig == "default" {
+		configPath, err = config.DefaultConfigPath()
 	} else {
-		configPath, err = filepath.Abs(specifiedConfig)
+		configPath, err = filepath.Abs(*specifiedConfig)
 	}
 	if err != nil {
 		return fmt.Errorf("Failed to get config path: %s", err)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -49,12 +49,12 @@ func RunExecute(c *Cmd) error {
 	specifiedConfig := ExtractSubCmdValue(Config, c.SubCmds)
 	var configPath string
 	var err error
-	if specifiedConfig == "default" {
-		configPath, err = config.DefaultConfigPath()
-	} else if specifiedConfig == "" {
+	if specifiedConfig == nil {
 		configPath, err = config.UsedConfig()
+	} else if *specifiedConfig == "default" {
+		configPath, err = config.DefaultConfigPath()
 	} else {
-		configPath, err = filepath.Abs(specifiedConfig)
+		configPath, err = filepath.Abs(*specifiedConfig)
 	}
 	if err != nil {
 		return fmt.Errorf("Failed to get config path: %s", err)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -5,19 +5,19 @@ import (
 )
 
 // returns empty string if not found in map of subcommands
-func ExtractSubCmdValue(val CmdType, subCmds map[CmdType]*Cmd) string {
+func ExtractSubCmdValue(val CmdType, subCmds map[CmdType]*Cmd) *string {
 	subCmd, ok := subCmds[val]
 	if !ok {
-		return ""
+		return nil
 	}
-	return subCmd.Value
+	return &subCmd.Value
 }
 
 // returns empty string if not found in map of flags
-func ExtractFlagValue(val flag.FlagType, flags map[flag.FlagType]*flag.Flag) string {
+func ExtractFlagValue(val flag.FlagType, flags map[flag.FlagType]*flag.Flag) *string {
 	flag, ok := flags[val]
 	if !ok {
-		return ""
+		return nil
 	}
-	return flag.Value
+	return &flag.Value
 }

--- a/config/change_wt_bg.go
+++ b/config/change_wt_bg.go
@@ -96,6 +96,8 @@ func (c *Config) ChangeBgImage(configPath string, profile *string, interval *str
 			}
 			if interval == nil {
 				intervalInt = c.Interval
+			} else {
+				intervalInt, _ = strconv.Atoi(*interval)
 			}
 			if align != nil {
 				overrideAlign = *align

--- a/config/change_wt_bg.go
+++ b/config/change_wt_bg.go
@@ -13,7 +13,7 @@ import (
 	"github.com/saltkid/tbg/utils"
 )
 
-func (c *Config) ChangeBgImage(configPath string, profile string, interval string, align string, stretch string, opacity string) error {
+func (c *Config) ChangeBgImage(configPath string, profile *string, interval *string, align *string, stretch *string, opacity *string) error {
 	// read settings.json
 	settingsPath, err := settingsJsonPath()
 	if err != nil {
@@ -90,21 +90,21 @@ func (c *Config) ChangeBgImage(configPath string, profile string, interval strin
 			}
 
 			// flags set by user on execution
-			intervalInt, _ := strconv.Atoi(interval)
-			if profile == "" {
-				profile = c.Profile
+			var intervalInt int
+			if profile == nil {
+				profile = &c.Profile
 			}
-			if interval == "" {
+			if interval == nil {
 				intervalInt = c.Interval
 			}
-			if align != "" {
-				overrideAlign = align
+			if align != nil {
+				overrideAlign = *align
 			}
-			if stretch != "" {
-				overrideStretch = stretch
+			if stretch != nil {
+				overrideStretch = *stretch
 			}
-			if opacity != "" {
-				overrideOpacity = opacity
+			if opacity != nil {
+				overrideOpacity = *opacity
 			}
 
 		imageLoop:
@@ -116,9 +116,9 @@ func (c *Config) ChangeBgImage(configPath string, profile string, interval strin
 
 				fmt.Println()
 				opacityF, _ := strconv.ParseFloat(overrideOpacity, 64)
-				c.Log(configPath).LogRunSettings(image, profile, intervalInt, overrideAlign, overrideStretch, opacityF)
+				c.Log(configPath).LogRunSettings(image, *profile, intervalInt, overrideAlign, overrideStretch, opacityF)
 
-				err = updateWtJsonFields(allData, settingsPath, profile, image, overrideAlign, overrideStretch, overrideOpacity)
+				err = updateWtJsonFields(allData, settingsPath, *profile, image, overrideAlign, overrideStretch, overrideOpacity)
 				if err != nil {
 					return err
 				}

--- a/config/config.go
+++ b/config/config.go
@@ -44,26 +44,21 @@ func (c *Config) Unmarshal(data []byte) error {
 	return nil
 }
 
-func (c *Config) AddPath(toAdd string, configPath string, align string, stretch string, opacity string) error {
+func (c *Config) AddPath(toAdd string, configPath string, align *string, stretch *string, opacity *string) error {
 	// set flags after path only if at least one is set
-	if align != "" || opacity != "" || stretch != "" {
-		if align == "" {
-			align = c.Alignment
+	if align != nil || opacity != nil || stretch != nil {
+		// inherit default values if not set
+		if align == nil {
+			align = &c.Alignment
 		}
-		if stretch == "" {
-			stretch = c.Stretch
+		if stretch == nil {
+			stretch = &c.Stretch
 		}
-		if opacity == "" {
-			opacity = strconv.FormatFloat(c.Opacity, 'f', -1, 64)
+		if opacity == nil {
+			tmp := strconv.FormatFloat(c.Opacity, 'f', -1, 64)
+			opacity = &tmp
 		}
-
-		isDefaultAlign := strings.EqualFold(align, c.Alignment)
-		isDefaultStretch := strings.EqualFold(stretch, c.Stretch)
-		isDefaultOpacity := strings.EqualFold(opacity, strconv.FormatFloat(c.Opacity, 'f', -1, 64))
-		// only add flags if all are not the default values
-		if !(isDefaultAlign && isDefaultStretch && isDefaultOpacity) {
-			toAdd = fmt.Sprintf("%s | %s %s %s", toAdd, align, stretch, opacity)
-		}
+		toAdd = fmt.Sprintf("%s | %s %s %s", toAdd, *align, *stretch, *opacity)
 	}
 
 	for _, path := range c.ImageColPaths {
@@ -114,34 +109,34 @@ func (c *Config) RemovePath(absPath string, configPath string) error {
 	c.Log(configPath).LogRemoved(removed)
 	return nil
 }
-func (c *Config) EditPath(arg string, configPath string, profile string, interval string, align string, stretch string, opacity string) error {
+func (c *Config) EditPath(arg string, configPath string, profile *string, interval *string, align *string, stretch *string, opacity *string) error {
 	// key:val = old:new
 	edited := make(map[string]string, 0)
 
 	// edit these two on a config level
-	if profile != "" {
-		edited[c.Profile] = profile
-		c.Profile = profile
+	if profile != nil {
+		edited[c.Profile] = *profile
+		c.Profile = *profile
 	}
-	if interval != "" {
-		edited[strconv.Itoa(c.Interval)] = interval
-		intervalInt, _ := strconv.Atoi(interval)
+	if interval != nil {
+		edited[strconv.Itoa(c.Interval)] = *interval
+		intervalInt, _ := strconv.Atoi(*interval)
 		c.Interval = intervalInt
 	}
 
 	if arg == "fields" {
 		// edit the rest of the fields on a config level too
-		if align != "" {
-			edited[c.Alignment] = align
-			c.Alignment = align
+		if align != nil {
+			edited[c.Alignment] = *align
+			c.Alignment = *align
 		}
-		if stretch != "" {
-			edited[c.Stretch] = stretch
-			c.Stretch = stretch
+		if stretch != nil {
+			edited[c.Stretch] = *stretch
+			c.Stretch = *stretch
 		}
-		if opacity != "" {
-			edited[strconv.FormatFloat(c.Opacity, 'f', -1, 64)] = opacity
-			opacityFloat, _ := strconv.ParseFloat(opacity, 64)
+		if opacity != nil {
+			edited[strconv.FormatFloat(c.Opacity, 'f', -1, 64)] = *opacity
+			opacityFloat, _ := strconv.ParseFloat(*opacity, 64)
 			c.Opacity = opacityFloat
 		}
 
@@ -164,38 +159,31 @@ func (c *Config) EditPath(arg string, configPath string, profile string, interva
 				}
 
 				currAlign, currStretch, currOpacity := strings.TrimSpace(optSlice[0]), strings.TrimSpace(optSlice[1]), strings.TrimSpace(optSlice[2])
-				if align == "" {
-					align = currAlign
+				if align == nil {
+					align = &currAlign
 				}
-				if stretch == "" {
-					stretch = currStretch
+				if stretch == nil {
+					stretch = &currStretch
 				}
-				if opacity == "" {
-					opacity = currOpacity
+				if opacity == nil {
+					opacity = &currOpacity
 				}
 			} else {
 				// use default values if not set
-				if align == "" {
-					align = c.Alignment
+				if align == nil {
+					align = &c.Alignment
 				}
-				if stretch == "" {
-					stretch = c.Stretch
+				if stretch == nil {
+					stretch = &c.Stretch
 				}
-				if opacity == "" {
-					opacity = strconv.FormatFloat(c.Opacity, 'f', -1, 64)
+				if opacity == nil {
+					tmp := strconv.FormatFloat(c.Opacity, 'f', -1, 64)
+					opacity = &tmp
 				}
 
 			}
 
-			// if all opts are equal to the defaults set in the config, just remove the options
-			isDefaultAlign := strings.EqualFold(align, c.Alignment)
-			isDefaultStretch := strings.EqualFold(stretch, c.Stretch)
-			isDefaultOpacity := strings.EqualFold(opacity, strconv.FormatFloat(c.Opacity, 'f', -1, 64))
-			if isDefaultAlign && isDefaultStretch && isDefaultOpacity {
-				c.ImageColPaths[i] = purePath // removed opts after | and just kept the path
-			} else {
-				c.ImageColPaths[i] = fmt.Sprintf("%s | %s %s %s", purePath, align, stretch, opacity)
-			}
+			c.ImageColPaths[i] = fmt.Sprintf("%s | %s %s %s", purePath, *align, *stretch, *opacity)
 
 			// check if path was edited for logging purposes
 			if path != c.ImageColPaths[i] {


### PR DESCRIPTION
closes #9 

### path flags are explicitly theirs
adding a path with the same flags as the default flag fields keeps the flags of the path instead removing the flags and just keeping the path.
editing a path to have flags the same as the default flag fields keeps the flags of the path instead of removing the flags.

This means paths with flags **explicitly** says that the flags they have are theirs, even if default flag fields change. No more implicit drops if path flags are equal to the default flag fields

see #9 for more info

### etc
- use pointer variables to differentiate between nil and empty string for example since these two have two very different meanings in whether the user specified the flag with no value or did not specify the flag

### todo for next pr
- since there's no implicit drops of flags, when a path has flags, it will always have flags. in order to remove them in this current implementation, you have to `tbg remove path/to/dir` then `tbg add path/to/dir` which is tedious. add a way to just remove the flags of a path. could add a flag for either `edit` or `remove`.
    - if flag for `remove`, its going to be something like this: `tbg remove path/to/dir --alignment --stretch --opacity`
        - the reason for needing 3 flags is because to keep consistency with `add` that only has these flags as well. I'm going to have to limit the validation of these flags for remove to: these flags must not have values (only that they are present)
    - if flag for edit, its going to be something like this: `tbg edit path/to/dir --no-flags`
    - leaning towards the remove solution