### PR TITLE
Flags for remove

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -51,7 +51,7 @@ func AddValidateFlag(f *flag.Flag) error {
 	case flag.Alignment, flag.Opacity, flag.Stretch:
 		return f.ValidateValue(f.Value)
 	default:
-		return fmt.Errorf("unexpected error: unknown flag: '%s'", f.Type.ToString())
+		return fmt.Errorf("invalid flag for 'add': '%s'", f.Type.ToString())
 	}
 }
 
@@ -63,7 +63,7 @@ func AddValidateSubCmd(c *Cmd) error {
 		}
 		return c.ValidateValue(c.Value)
 	default:
-		return fmt.Errorf("unexpected error: unknown sub command: '%s'", c.Type.ToString())
+		return fmt.Errorf("invalid sub command for 'add': '%s'", c.Type.ToString())
 	}
 }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -115,6 +115,8 @@ func (c *Cmd) ValidateValue(val string) error {
 		return HelpValidateValue(val)
 	case Version:
 		return nil
+	case None:
+		return nil
 	default:
 		return fmt.Errorf("unknown command: %s", val)
 	}
@@ -135,6 +137,8 @@ func (c *Cmd) ValidateFlag(f *flag.Flag) error {
 	case Help:
 		return HelpValidateFlag(f)
 	case Version:
+		return nil
+	case None:
 		return nil
 	default:
 		return fmt.Errorf("unexpected error: unknown command type: %d", c.Type)
@@ -157,6 +161,8 @@ func (c *Cmd) ValidateSubCmd(sc *Cmd) error {
 		return HelpValidateSubCmd(sc)
 	case Version:
 		return nil
+	case None:
+		return nil
 	default:
 		return fmt.Errorf("unexpected error: unknown command type: %d", sc.Type)
 	}
@@ -178,6 +184,8 @@ func (c *Cmd) Execute() error {
 		return HelpExecute(c)
 	case Version:
 		return VersionExecute()
+	case None:
+		return nil
 	default:
 		return fmt.Errorf("unexpected error: unknown command type: %d", c.Type)
 	}

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -30,7 +30,7 @@ func EditValidateFlag(f *flag.Flag) error {
 	case flag.Profile, flag.Interval, flag.Alignment, flag.Opacity, flag.Stretch:
 		return f.ValidateValue(f.Value)
 	default:
-		return fmt.Errorf("unexpected error: unknown flag: '%s'", f.Type.ToString())
+		return fmt.Errorf("invalid flag for 'edit': '%s'", f.Type.ToString())
 	}
 }
 
@@ -42,7 +42,7 @@ func EditValidateSubCmd(c *Cmd) error {
 		}
 		return c.ValidateValue(c.Value)
 	default:
-		return fmt.Errorf("unexpected error: unknown sub command type: '%s'", c.Type.ToString())
+		return fmt.Errorf("invalid sub command for 'edit': '%s'", c.Type.ToString())
 	}
 }
 

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -24,10 +24,13 @@ func RemoveValidateValue(val string) error {
 
 func RemoveValidateFlag(f *flag.Flag) error {
 	switch f.Type {
-	case flag.None:
+	case flag.Alignment, flag.Opacity, flag.Stretch:
+		if f.Value != "" {
+			return fmt.Errorf("'remove' flags don't take any values. flag '%s' has value: '%s'", f.Type.ToString(), f.Value)
+		}
 		return f.ValidateValue(f.Value)
 	default:
-		return fmt.Errorf("'remove' takes no flags. got: '%s'", f.Type.ToString())
+		return fmt.Errorf("invalid flag for 'remove': '%s'", f.Type.ToString())
 	}
 }
 
@@ -39,7 +42,7 @@ func RemoveValidateSubCmd(c *Cmd) error {
 		}
 		return c.ValidateValue(c.Value)
 	default:
-		return fmt.Errorf("unexpected error: unknown sub command type: '%s'", c.Type.ToString())
+		return fmt.Errorf("invalid sub command for 'remove': '%s'", c.Type.ToString())
 	}
 }
 

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -28,7 +28,7 @@ func RemoveValidateFlag(f *flag.Flag) error {
 		if f.Value != "" {
 			return fmt.Errorf("'remove' flags don't take any values. flag '%s' has value: '%s'", f.Type.ToString(), f.Value)
 		}
-		return f.ValidateValue(f.Value)
+		return nil
 	default:
 		return fmt.Errorf("invalid flag for 'remove': '%s'", f.Type.ToString())
 	}
@@ -48,6 +48,11 @@ func RemoveValidateSubCmd(c *Cmd) error {
 
 func RemoveExecute(c *Cmd) error {
 	toRemove, _ := filepath.Abs(c.Value)
+
+	// check if flags are set by user (empty if not)
+	align := ExtractFlagValue(flag.Alignment, c.Flags)
+	opacity := ExtractFlagValue(flag.Opacity, c.Flags)
+	stretch := ExtractFlagValue(flag.Stretch, c.Flags)
 
 	// check if config subcommand is set by user (empty if not)
 	specifiedConfig := ExtractSubCmdValue(Config, c.SubCmds)
@@ -74,7 +79,7 @@ func RemoveExecute(c *Cmd) error {
 		return err
 	}
 
-	err = configContents.RemovePath(toRemove, configPath)
+	err = configContents.RemovePath(toRemove, configPath, align, stretch, opacity)
 	if err != nil {
 		return err
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -21,7 +21,7 @@ func RunValidateFlag(f *flag.Flag) error {
 	case flag.Profile, flag.Interval, flag.Alignment, flag.Opacity, flag.Stretch:
 		return f.ValidateValue(f.Value)
 	default:
-		return fmt.Errorf("unexpected error: unknown flag: '%s'", f.Type.ToString())
+		return fmt.Errorf("invalid flag for 'run': '%s'", f.Type.ToString())
 	}
 }
 
@@ -33,7 +33,7 @@ func RunValidateSubCmd(sc *Cmd) error {
 		}
 		return sc.ValidateValue(sc.Value)
 	default:
-		return fmt.Errorf("unexpected error: unknown sub command: '%s'", sc.Type.ToString())
+		return fmt.Errorf("invalid sub command for 'run': '%s'", sc.Type.ToString())
 	}
 }
 

--- a/flag/flag.go
+++ b/flag/flag.go
@@ -74,6 +74,8 @@ func (f *Flag) ValidateValue(val string) error {
 		return ValidateOpacity(val)
 	case Stretch:
 		return ValidateStretch(val)
+	case None:
+		return nil
 	default:
 		return fmt.Errorf("unexpected error: unknown flag: %d", f.Type)
 	}


### PR DESCRIPTION
closes #11 

### overview
this is our config
```
image_col_paths
- path/to/dir | center fill 0.1
default_alignment: top
default_stretch: uniform
default_opacity: 0.5
```
if we do:
```
tbg remove path/to/images/dir -s
```
it will turn to this
```
image_col_paths
- path/to/dir | center uniform 0.1
default_alignment: top
default_stretch: uniform
default_opacity: 0.5
```
it removed the `--stretch` flag `fill` for `path/to/images/dir` and inherited from the default value instead, turning it into `uniform`. That's the "removal" process.

Of course if you specify all 3 flags (-s -a and -o), it will just remove the flags after the path and just keep `path/to/images/dir`

### Conditions:
1. if no flags are present, remove the entire path from `image_col_paths` field
2. if all 3 flags are present (-s -a and -o), remove all flags from path and just keep the path
3. if at least one flag from -s -a or -o is specified, it will 'remove' what was specified (replace with default flag field value) and keep the original value of those not specified.
    - there will be a check to see if the replaced flags are equal to the default flag fields. if all are equal, just remove the flags condition 2. if not, keep the flag changes