### PR TITLE
Feat/change random behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ or
 - clone the repo
 ```
 git clone git@github.com:saltkid/tbg.git
+cd tbg
 ```
 - build it:
 ```
-cd tbg && go mod tidy && go build -ldflags '-s'
+go mod tidy
+go build -ldflags '-s'
 ```
 **Optionally** add the `tbg` executable to your path
 
@@ -73,8 +75,11 @@ use the `config` command to edit them.
 1. **profile**
     - *args*: `default`, `list-0`, `list-1`, ...
     - target profile in *Windows Terminal*.
-    - To change background images in user created profiles, set `profile` to `list-<n>` where n is the index used by *Windows Terminal* to identify the profile.
-    - See [Microsoft's documentation](https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-general) for more information
+    - To change background images in user created profiles, set `profile` to
+    `list-<n>` where n is the index used by *Windows Terminal* to identify the
+    profile.
+    - See [Microsoft's documentation](https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-general)
+    for more information
 2. **interval**
     - *args*: any positive integer 
     - time in minutes between each image change.
@@ -115,11 +120,16 @@ For a more detailed explanation on each command, follow the command name links
 1. [run](https://github.com/saltkid/tbg/blob/main/docs/run_command_usage.md) 
     - *args*: none 
     - *flags*: `-p, --profile`, `-i, --interval`, `-a, --alignment`, `-o, --opacity`, `-s, --stretch` 
-    - edit `settings.json` used by *Windows Terminal* using settings from the currently used config.<br><br>If any of the `--`flags are specified, it will use those values in editing `settings.json` instead of what's specified in the currently used config
+    - edit `settings.json` used by *Windows Terminal* using settings from the
+    currently used config. If any of the flags are specified, it will use those
+    values in editing `settings.json` instead of what's specified in the
+    currently used config
 2. [config](https://github.com/saltkid/tbg/blob/main/docs/config_command_usage.md) 
     - *args*: none 
     - *flags*: `-p, --profile`, `-i, --interval`, `-a, --alignment`, `-o, --opacity`, `-s, --stretch` 
-    - If no flags are present, it will print out the currently used config to console.<br><br>If any of the flags are present, it will edit the fields of the config based on the flags and values passed
+    - If no flags are present, it will print out the currently used config to
+    console. If any of the flags are present, it will edit the fields of the
+    config based on the flags and values passed
 3. [add](https://github.com/saltkid/tbg/blob/main/docs/add_command_usage.md) 
     - `path/to/dir` 
     - *flags*: `-a, --alignment`, `-o, --opacity`, `-s, --stretch` 
@@ -143,11 +153,11 @@ Flags behave differently based on the parent command so for more detailed
 explanation, go to the documentation of the command instead.
 | Flag | Field Overriden |
 | --- | --- |
-| `--profile`<br>`-p` | `profile` |
-| `--interval`<br>`-i` | `interval` |
-| `--alignment`<br>`-a` | `alignment` |
-| `--opacity`<br>`-o` | `opacity` |
-| `--stretch`<br>`-s` | `stretch` |
+| `-p, --profile` | `profile` |
+| `-i, --interval` | `interval` |
+| `-a, --alignment` | `alignment` |
+| `-o, --opacity` | `opacity` |
+| `-s, --stretch` | `stretch` |
 
 ---
 # Credits

--- a/docs/run_command_usage.md
+++ b/docs/run_command_usage.md
@@ -16,10 +16,10 @@ settings from the currently used config. **tbg** will keep running, editing the
 `settings.json` of *Windows Terminal*, replacing the background image. You can
 quit by pressing `q` or `ctrl+c`
 
-On initial execution of **tbg**, it will create a `config.yaml` in the same
+On initial execution of **tbg**, it will create a `.tbg.yml` in the same
 directory as the **tbg** executable if it does not exist already. **There can
-only be one `config.yaml`**. For more information, see documentation on
-[config.yaml](https://github.com/saltkid/tbg/blob/main/docs/config.yaml.md).
+only be one `.tbg.yml`**. For more information, see documentation on
+[tbg.yml](https://github.com/saltkid/tbg/blob/main/docs/tbg.yml.md).
 
 # Key events
 **tbg** takes optional commands during execution:
@@ -27,18 +27,36 @@ only be one `config.yaml`**. For more information, see documentation on
 - `c`: shows the available commands
 - `n`: goes to next image
 - `p`: goes to previous image
-- `N`: goes to next image collection
-- `P`: goes to previous image collection
-- `r`: randomizes the images in the current image collection starting from the
+- `N`: goes to next images path
+- `P`: goes to previous images path
+- `r`: randomizes the images in the current images path starting from the
 current image
-    - this does not affect the order of the previous images
-- `R`: randomizes the images in the current image collection starting from the
+    - this does not affect the order of the previous images so you can go to
+    the same previous image/s
+- `R`: randomizes the images in the current images path starting from the
 current collection
     - this does not affect the order of the previous collections
 
 **tbg** will continue running until you press `q` or `ctrl+c`.
 This means even if all images are exhausted, **tbg** will wrap back around.
 For an example, see [usage with key events](#normal-execution)
+
+## Order Behavior
+The order of paths **and** the images in that path are randomized on
+initialize. However, you'd still have to consume all the images in a path
+before going to the next one. When you consumed all paths and wrap around to
+the first path again, the paths will be re-randomized. Even the images: from
+`path A`, when you go to next `path B`, then go to previous `path A`, the order
+of images in `path A` will be different from the first time you went to it,
+since images are also re-randomized every time you enter an images path.
+
+#### Order Behavior using `--random` flag
+The `--random` flag will ensure that whenever you go to the next image, it
+always will pick a random images path, then a random image from there. This
+means going to the next image `[n]` is the only valid command by the user. You
+cannot go to the next path `[N]`, previous image `[p]`, previous path `[P]`,
+randomize images `[r]`, or randomize paths `[R]`. More info about flags in the
+next section
 
 # Executing with flags
 #### Valid Flags: `--profile`, `--interval`, `--alignment`, `--opacity`, `--stretch`, `--random`
@@ -56,14 +74,6 @@ The order of importance is:
 3. default options fields in config
 
 For an example, see [overriding default flags walkthrough](#overriding-default-option-fields)
-
-#### Using `--random` flag
-The `--random` flag will randomize the order of image collections dirs **and**
-the images. Even if you consumed all paths and wrap around to the first path
-again, the paths will be re-randomized. Even the images: when you go to next
-dir B, then go to previous dir A, the order will be different from the first
-time you go to dir A, since images are also re-randomized every time you enter
-a dir.
 
 # Usage
 ### Normal Execution
@@ -95,7 +105,7 @@ first few images will be from `path/to/dir1`. The image will be at the
 **center**, **fill** the entire screen without regard of the original aspect
 ratio, with an opacity of **10%**. 
 
-When I press `n`, it goes to the next images without waiting for 30 minutes. I
+When I press `n`, it goes to the next image without waiting for 30 minutes. I
 can go back by pressing `p`.
 
 When I press `N`, it goes to the next image collection dir. This means we are

--- a/docs/tbg.yml.md
+++ b/docs/tbg.yml.md
@@ -62,9 +62,9 @@ Although you can edit the fields in the config directly, it is recommended to us
 | --- | --- | --- |
 | `profile` | `default`, `list-0`, `list-1` | target profile in *Windows Terminal*.<br><br>To change background images in user created profiles, set `profile` to `list-<n>` where n is the index used by *Windows Terminal* to identify the profile.<br><br>See [Microsoft's documentation](https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-general) for more information |
 | `interval` | any positive integer | time in minutes between each image change. |
-| `paths` | `[]`<br>`- path: path/to/dir1` | list of image collection paths. Must be directories containing images, not image paths.<br><br>Each path can override the default fields below. See [add command](https://github.com/saltkid/tbg/blob/main/docs/add_command_usage.md) and [edit command](https://github.com/saltkid/tbg/blob/main/docs/edit_command_usage.md)
-| `alignment` | `top`, `top-left`, `top-right`, `left`, `center`, `right`, `bottom`, `bottom-left`, `bottom-right` | image alignment in Windows Terminal. Can be overriden on a per-dir basis |
-| `stretch` | `uniform`, `fill`, `uniform-fill`, `none` | image stretch in Windows Terminal. Can be overriden on a per-dir basis |
+| `paths` | `[]`<br>`- path: path/to/dir1` | list of paths that contain images.e<br><br>Each path can override the default fields below. See [add command](https://github.com/saltkid/tbg/blob/main/docs/add_command_usage.md) 
+| `alignment` | `top`, `topLeft`, `topRight`, `left`, `center`, `right`, `bottom`, `bottomLeft`, `bottomRight` | image alignment in Windows Terminal. Can be overriden on a per-dir basis |
+| `stretch` | `uniform`, `fill`, `uniformToFill`, `none` | image stretch in Windows Terminal. Can be overriden on a per-dir basis |
 | `opacity` | inclusive range between `0` and `1` | image opacity of background images in Windows Terminal. Can be overriden on a per-dir basis |
 
 For the default flag fields (`alignment`, `stretch`, and `opacity`), see [Mircrosoft's documentation](https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-appearance#background-images-and-icons) for more information

--- a/tbg.go
+++ b/tbg.go
@@ -97,9 +97,7 @@ func (tbg *TbgState) Init() error {
 	if len(tbg.Config.Paths) == 0 {
 		return fmt.Errorf(`config at "%s" has no paths`, tbg.ConfigPath)
 	}
-	if tbg.Random {
-		ShuffleFrom(0, tbg.Paths)
-	}
+	ShuffleFrom(0, tbg.Paths)
 	err := tbg.UpdateCurrentPathState()
 	return err
 }
@@ -111,9 +109,7 @@ func (tbg *TbgState) UpdateCurrentPathState() error {
 	tbg.CurrentPathOpacity = Option(currentPath.Opacity).UnwrapOr(tbg.Config.Opacity)
 	var err error
 	tbg.Images, err = currentPath.Images()
-	if tbg.Random {
-		ShuffleFrom(0, tbg.Images)
-	}
+	ShuffleFrom(0, tbg.Images)
 	return err
 }
 
@@ -214,9 +210,7 @@ func (tbg *TbgState) NextPath() {
 	tbg.PathIndex++
 	if tbg.PathIndex >= uint16(len(tbg.Config.Paths)) {
 		fmt.Println("no more next dirs. going to first dir again: ", tbg.Config.Paths[0].Path)
-		if tbg.Random {
-			ShuffleFrom(0, tbg.Paths)
-		}
+		ShuffleFrom(0, tbg.Paths)
 		tbg.PathIndex = 0
 	}
 	tbg.UpdateCurrentPathState()
@@ -227,9 +221,7 @@ func (tbg *TbgState) PreviousPath() {
 	switch tbg.PathIndex {
 	case 0:
 		fmt.Println("no more previous dirs. going to last dir again: ", tbg.Config.Paths[len(tbg.Config.Paths)-1].Path)
-		if tbg.Random {
-			ShuffleFrom(0, tbg.Paths)
-		}
+		ShuffleFrom(0, tbg.Paths)
 		tbg.PathIndex = uint16(len(tbg.Config.Paths) - 1)
 	default:
 		tbg.PathIndex--

--- a/tbg.go
+++ b/tbg.go
@@ -153,13 +153,17 @@ func (tbg *TbgState) readUserInput() {
 	}
 }
 
+
+// Handles events emitted by various TbgState methods
 func (tbg *TbgState) Wait() error {
-	ticker := time.Tick(time.Duration(tbg.Config.Interval) * time.Minute)
-	// ticker := time.Tick(time.Second * 10) // for debug purposes
 	for {
+		ticker := time.Tick(time.Duration(tbg.Config.Interval) * time.Minute)
+		// ticker := time.Tick(time.Second * 5) // for debug purposes
 		select {
 		case <-ticker:
-			tbg.NextImage()
+			// in a go routine since NextImage can emit TbgState.Events.Errors
+			// and we want to catch that same event in this same loop
+			go tbg.NextImage()
 		case <-tbg.Events.Done:
 			fmt.Println("Goodbye!")
 			return nil

--- a/wt_settings.go
+++ b/wt_settings.go
@@ -54,6 +54,9 @@ func (wt *WTSettings) Write(
 	default:
 		err = writeToListProfile(profiles, profile, image, alignment, stretch, opacity)
 	}
+	if err != nil {
+		return err
+	}
 	// write profiles
 	updatedProfiles, err := json.Marshal(profiles)
 	if err != nil {


### PR DESCRIPTION
## Ordering changes
1. default ordering is now the old random ordering without changes:
    - on initialize, images paths are randomized then order of the images in the first path is randomized
    - still needs to consume all images in current path before going to the next one
    - when all paths are consumed, wrapping around re-randomizes the images paths, then the order of the images in the first path is randomized
2. new random ordering:
    - when going to the next image, picks a random images path then picks a random image in that path
    - removes the ability for the user to go back to previous image since it'll just be the same as next image
    - all removed commands:
      1. next path
      2. previous image
      3. previous path
      4. randomize images
      5. randomize paths
    - remaining commands
      1. command list
      2. next image
      3. quit