### PR TITLE
Docs/update docs, fix typos, remove outdated information

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,24 +107,23 @@ For a more detailed explanation on each command, follow the command name links
     - *flags*: `-p, --profile`, `-i, --interval`, `-a, --alignment`, `-o, --opacity`, `-s, --stretch`, `-r, --random`
     - edit `settings.json` used by *Windows Terminal* using settings from
     `.tbg.yml`. If any of the flags are specified, it will use those values in
-    editing `settings.json` instead of what's specified in the currently used
-    config
+    editing `settings.json` instead of what's specified in the `.tbg.yml`
 2. [config](https://github.com/saltkid/tbg/blob/main/docs/config_command_usage.md) 
     - *args*: none 
     - *flags*: `-p, --profile`, `-i, --interval`, `-a, --alignment`, `-o, --opacity`, `-s, --stretch` 
-    - If no flags are present, it will print out the currently used config to
-    console. If any of the flags are present, it will edit the fields of the
-    config based on the flags and values passed
+    - If no flags are present, it will print out `.tbg.yml` to console. If any
+    of the flags are present, it will edit the fields of the config based on
+    the flags and values passed
 3. [add](https://github.com/saltkid/tbg/blob/main/docs/add_command_usage.md) 
     - `path/to/dir` 
     - *flags*: `-a, --alignment`, `-o, --opacity`, `-s, --stretch` 
-    - Add a path containing images to the currently used config.
+    - Add a path containing images to `.tbg.yml`.
     - If any flags are present, it will add those options to that path,
     regardless of whether the path exists or not
 4. [remove](https://github.com/saltkid/tbg/blob/main/docs/remove_command_usage.md) 
     - `path/to/dir` 
     - *flags*: `-a, --alignment`, `-o, --opacity`, `-s, --stretch` 
-    - Remove a path from the currently used config.
+    - Remove a path from `.tbg.yml`.
     - If any flags are present, it will remove only those options of that path
 5. help
     - args: no arg, or any command or any flag (can be multiple)

--- a/README.md
+++ b/README.md
@@ -60,26 +60,20 @@ Here's a list of commands:
 
 See [fields](#fields) for more information about images paths.
 
-The images paths wrap around so if you go past the last image in the last images
-path, it will go back to the first image in the first images path. Same goes for
-the reverse direction.
+The images paths wrap around so if you go past the last image in the last path,
+it will go back to the first image in the first images path. Same goes for the
+reverse direction.
 
 # Config
-This is what is used by **tbg** to edit the `settings.json` *Windows Terminal*
-uses. As stated earlier, **tbg** creates a `.tbg.yml` in the same path as the
-**tbg** executable on intial execution.
+`.tbg.yml` is what is used by **tbg** to edit the `settings.json` *Windows
+Terminal* uses.
 
 ## Fields
 Although you can edit the fields in the config directly, it is recommended to
-use the `config` command to edit them.
+use the [`config`](https://github.com/saltkid/tbg/blob/main/docs/config_command_usage.md) command to edit them.
 1. **profile**
     - *args*: `default`, `list-0`, `list-1`, ...
     - target profile in *Windows Terminal*.
-    - To change background images in user created profiles, set `profile` to
-    `list-<n>` where n is the index used by *Windows Terminal* to identify the
-    profile.
-    - See [Microsoft's documentation](https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-general)
-    for more information
 2. **interval**
     - *args*: any positive integer 
     - time in minutes between each image change.
@@ -92,38 +86,29 @@ use the `config` command to edit them.
               alignment: center      # optional
               stretch: uniformToFill # optional
               opacity: 1.0           # optional
-    - list of paths containing subdirectories that contain images.
-    - Each path can override the default fields below.
-    - default values for per-path options if not specified are:
-        - `alignment: center`
-        - `stretch: uniformToFill`
-        - `opacity: 1.0`
+    - paths containing images used in changing the background image of Windows Terminal
 4. **alignment**
     - ( args ): `top`, `topLeft`, `topRight`, `left`, `center`, `right`, `bottom`, `bottomLeft`, `bottomRight` 
     - image alignment in Windows Terminal.
     - Can be overriden on a per-path basis
 5. `stretch` 
     - *args*: `uniform`, `fill`, `uniformToFill`, `none` 
-    - image stretch in Windows Terminal. Can be overriden on a per-path basis |
+    - image stretch in Windows Terminal. Can be overriden on a per-path basis
 6. `opacity` 
     - *args*: inclusive range between `0` and `1` 
     - image opacity of background images in Windows Terminal.
     - Can be overriden on a per-path basis
-
-For the default flag fields (`alignment`, `stretch`, and `opacity`), see
-[Mircrosoft's documentation](https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-appearance#background-images-and-icons)
-for more information
 
 # Commands
 For a more detailed explanation on each command, follow the command name links
 
 1. [run](https://github.com/saltkid/tbg/blob/main/docs/run_command_usage.md) 
     - *args*: none 
-    - *flags*: `-p, --profile`, `-i, --interval`, `-a, --alignment`, `-o, --opacity`, `-s, --stretch` 
-    - edit `settings.json` used by *Windows Terminal* using settings from the
-    currently used config. If any of the flags are specified, it will use those
-    values in editing `settings.json` instead of what's specified in the
-    currently used config
+    - *flags*: `-p, --profile`, `-i, --interval`, `-a, --alignment`, `-o, --opacity`, `-s, --stretch`, `-r, --random`
+    - edit `settings.json` used by *Windows Terminal* using settings from
+    `.tbg.yml`. If any of the flags are specified, it will use those values in
+    editing `settings.json` instead of what's specified in the currently used
+    config
 2. [config](https://github.com/saltkid/tbg/blob/main/docs/config_command_usage.md) 
     - *args*: none 
     - *flags*: `-p, --profile`, `-i, --interval`, `-a, --alignment`, `-o, --opacity`, `-s, --stretch` 

--- a/command_help.go
+++ b/command_help.go
@@ -140,12 +140,7 @@ func RunHelp(verbose bool) {
 		fmt.Print(`
   `, Decorate("Args").Bold(), `: run takes no args
 
-  `, Decorate("Subcommands").Bold(), `
-  1. config [arg]
-     [default, path/to/a/config.yaml]
-     You can specify which config to read from using the 'config' subcommand.
-     If you do not specify a config, the currently used config will be used.
-
+  `, Decorate("Subcommands").Bold(), `: run takes no sub-commands
   `, Decorate("Flags").Bold(), `:,
   You can specify alignment, stretch, and opacity using flags.
   These will override the values in the used config (not edit)
@@ -176,14 +171,9 @@ func RunHelp(verbose bool) {
 
   `, Decorate("Examples").Bold(), `:
   1. tbg run
-     This will use the currently used config's values to edit Windows Terminal's settings.json
+     This will use .tbg.yml's values to edit Windows Terminal's settings.json
 
-  2. tbg run config path/to/a/config.yaml 
-     tbg run config default 
-     These two are similar in the sense that this will have tbg use whatever
-     config was specified to edit Windows Terminal's settings.json
-
-  3. tbg run --profile list-2 --interval 5 --alignment center
+  2. tbg run --profile list-2 --interval 5 --alignment center
       used_config                      values used to edit settings.json
       --------------------------       --------------------------------
       | paths:                         | paths:
@@ -213,7 +203,7 @@ func RunHelp(verbose bool) {
 func AddHelp(verbose bool) {
 	fmt.Printf("%-33s%s",
 		Decorate("  add").Bold(),
-		"Adds a path containing images to currently used config\n",
+		"Adds a path containing images to .tbg.yml\n",
 	)
 	if verbose {
 		fmt.Print(`
@@ -222,12 +212,7 @@ func AddHelp(verbose bool) {
      Path to images dir should have at least one image
      file under it. All subdirectories will be ignored.
 
-  `, Decorate("Subcommands").Bold(), `:
-  1. config [arg]
-     [default, path/to/a/config.yaml]
-     You can specify which config to add to using the 'config' subcommand.
-     If you do not specify a config, the currently used config will be used.
-
+  `, Decorate("Subcommands").Bold(), `: add takes no sub-commands
   `, Decorate("Flags").Bold(), `:
   You can specify alignment, stretch, and opacity using flags. See example 2 and 3
   1. -a, --alignment [arg]
@@ -297,19 +282,14 @@ func AddHelp(verbose bool) {
 func RemoveHelp(verbose bool) {
 	fmt.Printf("%-33s%s",
 		Decorate("  remove").Bold(),
-		"Removes a path from the currently used config\n",
+		"Removes a path from .tbg.yml\n",
 	)
 	if verbose {
 		fmt.Print(`
   `, Decorate("Args").Bold(), `:
   1. path/to/images/dir
 
-  `, Decorate("Subcommands").Bold(), `:
-  1. config [arg]
-     [default, path/to/a/config.yaml]
-     You can specify which config to remove from using the 'config' subcommand.
-     If you do not specify a config, the currently used config will be used.
-
+  `, Decorate("Subcommands").Bold(), `: remove takes no sub-commands
   `, Decorate("Flags").Bold(), `:
   You can remove alignment, stretch, and opacity flags from a path by specifying flags
   See example 2 and 3
@@ -369,19 +349,12 @@ func RemoveHelp(verbose bool) {
 func ConfigHelp(verbose bool) {
 	fmt.Printf("%-33s%s",
 		Decorate("  config").Bold(),
-		"Prints the currently used config if no arg.\n",
+		"Prints .tbg.yml if no flags.\n",
 	)
 	if verbose {
 		fmt.Print(`
-  `, Decorate("Args").Bold(), `:
-  1. path/to/a-config.yaml
-     Sets this path as the currently used config.
-     It does this by editing the 'used_config' field on tbg_profile.yaml
-     in the same directory as the tbg executable (auto generated)
-  2. no arg
-     Prints the currently used config.
-
-  `, Decorate("Subcommands").Bold(), `: config takes no subcommands
+  `, Decorate("Args").Bold(), `: config takes no args
+  `, Decorate("Subcommands").Bold(), `: config takes no sub-commands
   `, Decorate("Flags").Bold(), `:
   1. -a, --alignment [arg]
          [top, topLeft, topRight, left, center, right, bottomLeft, bottom, bottomRight]
@@ -398,7 +371,7 @@ func ConfigHelp(verbose bool) {
 
   `, Decorate("Examples").Bold(), `:
   1. tbg config
-      print currently used config:
+      print .tbg.yml:
       --------------------------
       | paths:
       |   - path: /path/to/images/dir
@@ -454,7 +427,7 @@ func HelpHelp(verbose bool) {
 
 func VersionHelp(verbose bool) {
 	fmt.Printf("%-33s%s",
-		Decorate("  version").Bold(),
+		Decorate("  -v, --version").Bold(),
 		"Prints the version of tbg\n",
 	)
 	if verbose {
@@ -484,7 +457,7 @@ func ProfileHelp(verbose bool) {
 
   `, Decorate("Examples").Bold(), `:
   1. tbg run --profile default
-     whatever value the "profile" field in the currently used config will
+     whatever value the "profile" field in .tbg.yml will
      be ignored and tbg will edit the default Windows Terminal profile instead
 
   2. tbg edit --profile list-2 config /path/to/a/config.yaml
@@ -506,7 +479,7 @@ func IntervalHelp(verbose bool) {
 
   `, Decorate("Examples").Bold(), `:
   1. tbg run --interval 30
-     whatever value the \"interval\" field in the currently used config will
+     whatever value the \"interval\" field in .tbg.yml will
      be ignored and tbg change images every 30 minutes instead.
 
   2. tbg edit --interval 30 config /path/to/a/config.yaml
@@ -530,7 +503,7 @@ func AlignmentHelp(verbose bool) {
 
   `, Decorate("Examples").Bold(), `:
   1. tbg run --alignment center
-     whatever value the "alignment" field in the currently used config will
+     whatever value the "alignment" field in .tbg.yml will
      be ignored and tbg will center the image instead
 
   2. tbg edit --alignment center config /path/to/a/config.yaml
@@ -552,7 +525,7 @@ func StretchHelp(verbose bool) {
 
   `, Decorate("Examples").Bold(), `:
   1. tbg run --stretch fill
-     whatever value the \"stretch\" field in the currently used config will
+     whatever value the \"stretch\" field in .tbg.yml will
      be ignored and tbg will upscale the image to exactly fill the screen instead
 
   2. tbg edit --stretch fill config /path/to/a/config.yaml
@@ -574,7 +547,7 @@ func OpacityHelp(verbose bool) {
 
   `, Decorate("Examples").Bold(), `:
   1. tbg run --opacity 0.5
-     whatever value the "opacity" field in the currently used config will
+     whatever value the "opacity" field in .tbg.yml will
      be ignored and tbg will set the image opacity to 0.5
 
   2. tbg edit --opacity 0.5 config /path/to/a/config.yaml
@@ -596,7 +569,7 @@ func RandomHelp(verbose bool) {
   `, Decorate("Examples").Bold(), `:
   1. tbg run --random
      This will randomize the order of the image collections read
-     from the currently used config. It randomizes the order the
+     from .tbg.yml. It randomizes the order the
      images in each collection.
 
      When image collections are exhausted and tbg wraps around, the

--- a/docs/add_command_usage.md
+++ b/docs/add_command_usage.md
@@ -10,7 +10,7 @@
 
 # `tbg add [arg] [--flags]`
 #### args: `path/to/images/dir`
-`add` command adds a path to **tbg**'s currently used config.
+`add` command adds a path to `.tbg.yml`.
 You can add options to a path to be added using flags
 
 # Valid Flags
@@ -26,7 +26,7 @@ You can add options to a path to be added using flags
 
 # Usage
 ### Adding a path
-Let's say this is the currently used config:
+Let's say this is `.tbg.yml`:
 ```yml
 paths: []
 
@@ -40,7 +40,7 @@ If we run:
 ```bash
 tbg add path/to/images/dir1
 ```
-It will add `path/to/images/dir1` to the currently used config's `paths` field
+It will add `path/to/images/dir1` to `.tbg.yml`'s `paths` field
 like this:
 ```yml
 paths:

--- a/docs/config_command_usage.md
+++ b/docs/config_command_usage.md
@@ -33,7 +33,7 @@ based on flags passed to it.
 
 # Usage
 #### Printing config
-To print the currently used config, just do
+To print the `.tbg.yml`, just do
 ```bash
 tbg config
 ```

--- a/docs/remove_command_usage.md
+++ b/docs/remove_command_usage.md
@@ -8,7 +8,7 @@
 
 # `tbg remove [arg] [--flags]`
 #### args: `path/to/images/dir`
-`remove` command removes a path to **tbg**'s currently used config.
+`remove` command removes a path to **tbg**'s `.tbg.yml`.
 You can remove flags from a path using `--`flags
 
 # Valid Flags
@@ -24,7 +24,7 @@ You can remove flags from a path using `--`flags
 
 # Usage
 ### Removing a path
-Let's say this is the currently used config:
+Let's say this is the `.tbg.yml`:
 ```yml
 paths:
 - path: path/to/images/dir1
@@ -39,7 +39,7 @@ If we run:
 ```bash
 tbg remove path/to/images/dir1
 ```
-It will remove `path/to/images/dir1` from the currently used config's `paths`
+It will remove `path/to/images/dir1` from the `.tbg.yml`'s `paths`
 field like this:
 ```yml
 paths: []

--- a/docs/run_command_usage.md
+++ b/docs/run_command_usage.md
@@ -1,8 +1,9 @@
 # Table of Contents
 - [Overview](#tbg-run)
 - [Key events](#key-events)
+    - [Order Behavior](#ordering-behavior)
+    - [Order Behavior Using `--random` flag](#ordering-behavior-using-random-flag)
 - [Executing with flags](#executing-with-flags)
-    - [Using `--random` flag](#using---random-flag)
 - [Usage](#usage)
     - [Normal Execution, key events, and path specific options](#normal-execution)
     - [Overriding `profile` and `interval` fields](#overriding-profile-and-interval-fields)
@@ -41,7 +42,7 @@ current collection
 This means even if all images are exhausted, **tbg** will wrap back around.
 For an example, see [usage with key events](#normal-execution)
 
-## Order Behavior
+## Ordering Behavior
 The order of paths **and** the images in that path are randomized on
 initialize. However, you'd still have to consume all the images in a path
 before going to the next one. When you consumed all paths and wrap around to
@@ -50,7 +51,7 @@ the first path again, the paths will be re-randomized. Even the images: from
 of images in `path A` will be different from the first time you went to it,
 since images are also re-randomized every time you enter an images path.
 
-#### Order Behavior using `--random` flag
+## Ordering Behavior using `--random` flag
 The `--random` flag will ensure that whenever you go to the next image, it
 always will pick a random images path, then a random image from there. This
 means going to the next image `[n]` is the only valid command by the user. You

--- a/docs/run_command_usage.md
+++ b/docs/run_command_usage.md
@@ -13,7 +13,7 @@
 # `tbg run`
 
 `run` command edits the `settings.json` used by *Windows Terminal* using
-settings from the currently used config. **tbg** will keep running, editing the
+settings from `.tbg.yml`. **tbg** will keep running, editing the
 `settings.json` of *Windows Terminal*, replacing the background image. You can
 quit by pressing `q` or `ctrl+c`
 

--- a/docs/tbg.yml.md
+++ b/docs/tbg.yml.md
@@ -58,13 +58,44 @@ opacity: 0.1
 ```
 ## Fields
 Although you can edit the fields in the config directly, it is recommended to use the [`config` command](https://github.com/saltkid/tbg/blob/main/docs/config_command_usage.md) to edit them.
-| Field | Valid Values | Description |
-| --- | --- | --- |
-| `profile` | `default`, `list-0`, `list-1` | target profile in *Windows Terminal*.<br><br>To change background images in user created profiles, set `profile` to `list-<n>` where n is the index used by *Windows Terminal* to identify the profile.<br><br>See [Microsoft's documentation](https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-general) for more information |
-| `interval` | any positive integer | time in minutes between each image change. |
-| `paths` | `[]`<br>`- path: path/to/dir1` | list of paths that contain images.e<br><br>Each path can override the default fields below. See [add command](https://github.com/saltkid/tbg/blob/main/docs/add_command_usage.md) 
-| `alignment` | `top`, `topLeft`, `topRight`, `left`, `center`, `right`, `bottom`, `bottomLeft`, `bottomRight` | image alignment in Windows Terminal. Can be overriden on a per-dir basis |
-| `stretch` | `uniform`, `fill`, `uniformToFill`, `none` | image stretch in Windows Terminal. Can be overriden on a per-dir basis |
-| `opacity` | inclusive range between `0` and `1` | image opacity of background images in Windows Terminal. Can be overriden on a per-dir basis |
+1. **profile**
+    - *args*: `default`, `list-0`, `list-1`, ...
+    - target profile in *Windows Terminal*.
+    - To change background images in user created profiles, set `profile` to
+    `list-<n>` where n is the index used by *Windows Terminal* to identify the
+    profile.
+    - See [Microsoft's documentation](https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-general)
+    for more information
+2. **interval**
+    - *args*: any positive integer 
+    - time in minutes between each image change.
+3. **paths** 
+    - *args*:
+        - `[]`
+        - `- path: path/to/dir1` 
+        - ```yaml
+            - path: path/to/dir2
+              alignment: center      # optional
+              stretch: uniformToFill # optional
+              opacity: 1.0           # optional
+    - paths containing images used in changing the background image of Windows Terminal
+    - Each path can override the default fields below.
+    - default values for per-path options if not specified are:
+        - `alignment: center`
+        - `stretch: uniformToFill`
+        - `opacity: 1.0`
+4. **alignment**
+    - ( args ): `top`, `topLeft`, `topRight`, `left`, `center`, `right`, `bottom`, `bottomLeft`, `bottomRight` 
+    - image alignment in Windows Terminal.
+    - Can be overriden on a per-path basis
+5. `stretch` 
+    - *args*: `uniform`, `fill`, `uniformToFill`, `none` 
+    - image stretch in Windows Terminal. Can be overriden on a per-path basis |
+6. `opacity` 
+    - *args*: inclusive range between `0` and `1` 
+    - image opacity of background images in Windows Terminal.
+    - Can be overriden on a per-path basis
 
-For the default flag fields (`alignment`, `stretch`, and `opacity`), see [Mircrosoft's documentation](https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-appearance#background-images-and-icons) for more information
+For the default flag fields (`alignment`, `stretch`, and `opacity`), see
+[Mircrosoft's documentation](https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-appearance#background-images-and-icons)
+for more information


### PR DESCRIPTION
## Changes
1. simplify README.md
  - specifically the config section
  - point to config documentation in `docs/` instead
2. fixed some typos and outdated informatino
  - specifically references to "currently used config" since now, `.tbg.yml` is the only valid config file
3. update help messages printed out to console using `help` command
  - there were some outdated info