### PR TITLE
refactor(command): profile no longer needs `list-` prefix to identify the profile number

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Terminal* uses.
 Although you can edit the fields in the config directly, it is recommended to
 use the [`config`](https://github.com/saltkid/tbg/blob/main/docs/config_command_usage.md) command to edit them.
 1. **profile**
-    - *args*: `default`, `list-0`, `list-1`, ...
+    - *args*: `default`, `0`, `1`, ...
     - target profile in *Windows Terminal*.
 2. **interval**
     - *args*: any positive integer 

--- a/command_help.go
+++ b/command_help.go
@@ -151,8 +151,8 @@ func RunHelp(verbose bool) {
   3. -s, --stretch   [arg]
          [fill, none, uniform, uniformToFill]
   4. -p, --profile   [arg]
-         [default, list-n]
-         where n is the list index Windows Terminal uses to identify the profile
+         [default, n]
+         where n is the list index Windows Terminal uses to identify the profile (starting from 1)
   5. -i, --interval  [arg]
          [any positive integer]
          note that this is in minutes
@@ -173,14 +173,14 @@ func RunHelp(verbose bool) {
   1. tbg run
      This will use .tbg.yml's values to edit Windows Terminal's settings.json
 
-  2. tbg run --profile list-2 --interval 5 --alignment center
+  2. tbg run --profile 2 --interval 5 --alignment center
       used_config                      values used to edit settings.json
       --------------------------       --------------------------------
       | paths:                         | paths:
       |   - path: /path/to/images/dir1 |   - path: /path/to/images/dir1
       |   - path: /path/to/images/dir2 |   - path: /path/to/images/dir2
       |                                |
-      | profile: default               | profile: list-2
+      | profile: default               | profile: 2
       | interval: 30                   | interval: 5
       |                                |
       | alignment: right               | alignment: center
@@ -363,8 +363,8 @@ func ConfigHelp(verbose bool) {
   3. -s, --stretch   [arg]
          [fill, none, uniform, uniformToFill]
   4. -p, --profile   [arg]
-         [default, list-n]
-         where n is the list index Windows Terminal uses to identify the profile.
+         [default, n]
+         where n is the list index Windows Terminal uses to identify the profile (starting from 1)
   5. -i, --interval  [arg]
          [any positive integer]
          note that this is in minutes.
@@ -452,17 +452,17 @@ func ProfileHelp(verbose bool) {
   1. default
      Sets the default profile as the profile to be used
      by the parent command
-  2. list-n
-     where n is the list index Windows Terminal uses to identify the profile
+  2. n
+     where n is the list index Windows Terminal uses to identify the profile (starting from 1)
 
   `, Decorate("Examples").Bold(), `:
   1. tbg run --profile default
      whatever value the "profile" field in .tbg.yml will
      be ignored and tbg will edit the default Windows Terminal profile instead
 
-  2. tbg edit --profile list-2 config /path/to/a/config.yaml
+  2. tbg edit --profile 2 config /path/to/a/config.yaml
      this will change the "profile" field on the config /path/to/a/config.yaml
-     to "list-2"
+     to 2
 `)
 	}
 }

--- a/config_template.go
+++ b/config_template.go
@@ -67,7 +67,7 @@ opacity: 1.0
 #                  uses default opacity (see "opacity" field) if not specified
 #
 #   profile: profile profile in Windows Terminal
-#      valid values: default, list-0, list-1, ..., list-n
+#      valid values: default, 0, 1, ..., n
 #      https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-general
 #
 #   interval: time in minutes between each image change

--- a/docs/config_command_usage.md
+++ b/docs/config_command_usage.md
@@ -16,7 +16,7 @@ based on flags passed to it.
 
 # Valid Flags
 1. `--profile [arg]`
-    - args: `default`, `list-1`, `list-2`, ..., `list-<n>`
+    - args: `default`, `1`, `2`, ..., `<n>`
     - edits: `profile`
 2. `--interval [arg]`
     - args: `topRight`, `top`, `topLeft`, `left`, `center`, `right`, `bottomLeft`, `bottom`, `bottomRight`
@@ -80,7 +80,7 @@ tbg config --alignment topRight
 ```
 You can do this with the other four fields as well
 ```bash
-tbg config --profile list-1 --interval 5 --stretch fill --opacity 0.35
+tbg config --profile 1 --interval 5 --stretch fill --opacity 0.35
 ```
 ```bash
 ------------------------------------------------------------------------------------
@@ -92,7 +92,7 @@ tbg config --profile list-1 --interval 5 --stretch fill --opacity 0.35
 |   stretch: fill
 |   opacity: 0.250000
 |
-| profile:               list-1   # used to be default
+| profile:               1        # used to be default
 | interval:              5        # used to be 30
 | alignment:             topRight
 | stretch:               fill     # used to be uniform

--- a/docs/run_command_usage.md
+++ b/docs/run_command_usage.md
@@ -129,7 +129,7 @@ Now let's quit **tbg** by pressing `q` or `ctrl+c`.
 
 Instead of `tbg run`, let's do:
 ```bash
-tbg run --profile list-1 --interval 5
+tbg run --profile 1 --interval 5
 ```
 ```yml
 paths:

--- a/docs/tbg.yml.md
+++ b/docs/tbg.yml.md
@@ -38,7 +38,7 @@ opacity: 0.1
 #                  uses default opacity (see "opacity" field) if not specified
 #
 #   profile: profile profile in Windows Terminal
-#      valid values: default, list-0, list-1, ..., list-n
+#      valid values: default, 0, 1, ..., n
 #      https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-general
 #
 #   interval: time in minutes between each image change
@@ -59,10 +59,10 @@ opacity: 0.1
 ## Fields
 Although you can edit the fields in the config directly, it is recommended to use the [`config` command](https://github.com/saltkid/tbg/blob/main/docs/config_command_usage.md) to edit them.
 1. **profile**
-    - *args*: `default`, `list-0`, `list-1`, ...
+    - *args*: `default`, `0`, `1`, ...
     - target profile in *Windows Terminal*.
     - To change background images in user created profiles, set `profile` to
-    `list-<n>` where n is the index used by *Windows Terminal* to identify the
+    `<n>` where n is the index used by *Windows Terminal* to identify the
     profile.
     - See [Microsoft's documentation](https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-general)
     for more information

--- a/flag_validators.go
+++ b/flag_validators.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"strconv"
-	"strings"
 )
 
 func ValidateProfile(val *string) (*string, error) {
@@ -13,16 +12,9 @@ func ValidateProfile(val *string) (*string, error) {
 	if *val == "default" {
 		return val, nil
 	}
-	list, num, isList := strings.Cut(*val, "-")
-	if list != "list" {
-		return nil, fmt.Errorf("invalid arg '%s' for --profile: must be 'list' followed by a dash then number", *val)
-	}
-	if !isList {
-		return nil, fmt.Errorf("invalid arg '%s' for --profile: list and number must be separated by '-'", *val)
-	}
-	_, err := strconv.Atoi(num)
+	_, err := strconv.Atoi(*val)
 	if err != nil {
-		return nil, fmt.Errorf("invalid arg '%s' for --profile: %s", *val, err.Error())
+		return nil, fmt.Errorf("invalid arg '%s' for --profile: must be a number. %s", *val, err.Error())
 	}
 	return val, nil
 }

--- a/wt_settings.go
+++ b/wt_settings.go
@@ -116,8 +116,7 @@ func writeToListProfile(
 	if err != nil {
 		return fmt.Errorf(`Failed to unmarshal field "list" from field "profiles" in settings.json: %s`, err)
 	}
-	_, num, _ := strings.Cut(profile, "-")
-	profileNum, _ := strconv.Atoi(num)
+	profileNum, _ := strconv.Atoi(profile)
 	profileList[profileNum-1]["backgroundImage"] = json.RawMessage([]byte(image))
 	profileList[profileNum-1]["backgroundImageAlignment"] = json.RawMessage([]byte(alignment))
 	profileList[profileNum-1]["backgroundImageStretchMode"] = json.RawMessage([]byte(stretch))


### PR DESCRIPTION
It now just needs the number. updated docs to reflect changes as well