### PR TITLE
Feat/remove default config values

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,17 +87,6 @@ use the [`config`](https://github.com/saltkid/tbg/blob/main/docs/config_command_
               stretch: uniformToFill # optional
               opacity: 1.0           # optional
     - paths containing images used in changing the background image of Windows Terminal
-4. **alignment**
-    - ( args ): `top`, `topLeft`, `topRight`, `left`, `center`, `right`, `bottom`, `bottomLeft`, `bottomRight` 
-    - image alignment in Windows Terminal.
-    - Can be overriden on a per-path basis
-5. `stretch` 
-    - *args*: `uniform`, `fill`, `uniformToFill`, `none` 
-    - image stretch in Windows Terminal. Can be overriden on a per-path basis
-6. `opacity` 
-    - *args*: inclusive range between `0` and `1` 
-    - image opacity of background images in Windows Terminal.
-    - Can be overriden on a per-path basis
 
 # Commands
 For a more detailed explanation on each command, follow the command name links
@@ -110,7 +99,7 @@ For a more detailed explanation on each command, follow the command name links
     editing `settings.json` instead of what's specified in the `.tbg.yml`
 2. [config](https://github.com/saltkid/tbg/blob/main/docs/config_command_usage.md) 
     - *args*: none 
-    - *flags*: `-p, --profile`, `-i, --interval`, `-a, --alignment`, `-o, --opacity`, `-s, --stretch` 
+    - *flags*: `-p, --profile`, `-i, --interval`
     - If no flags are present, it will print out `.tbg.yml` to console. If any
     of the flags are present, it will edit the fields of the config based on
     the flags and values passed

--- a/command_config.go
+++ b/command_config.go
@@ -32,18 +32,18 @@ func (cmd *ConfigCommand) ValidateValue(val *string) error {
 
 func (cmd *ConfigCommand) ValidateFlag(f Flag) error {
 	switch f.Type {
-	case ProfileFlag:
-		val, err := ValidateProfile(f.Value)
-		if err != nil {
-			return err
-		}
-		cmd.Profile = val
 	case IntervalFlag:
 		val, err := ValidateInterval(f.Value)
 		if err != nil {
 			return err
 		}
 		cmd.Interval = val
+	case ProfileFlag:
+		val, err := ValidateProfile(f.Value)
+		if err != nil {
+			return err
+		}
+		cmd.Profile = val
 	default:
 		return fmt.Errorf("invalid flag for 'config': '%s'", f.Type)
 	}

--- a/command_config.go
+++ b/command_config.go
@@ -6,11 +6,8 @@ import (
 )
 
 type ConfigCommand struct {
-	Profile   *string
-	Interval  *uint16
-	Alignment *string
-	Stretch   *string
-	Opacity   *float32
+	Profile  *string
+	Interval *uint16
 }
 
 func (cmd *ConfigCommand) Type() CommandType { return ConfigCommandType }
@@ -23,15 +20,6 @@ func (cmd *ConfigCommand) Debug() {
 	}
 	if cmd.Interval != nil {
 		fmt.Println(" ", IntervalFlag, *cmd.Interval)
-	}
-	if cmd.Alignment != nil {
-		fmt.Println(" ", AlignmentFlag, *cmd.Alignment)
-	}
-	if cmd.Stretch != nil {
-		fmt.Println(" ", StretchFlag, *cmd.Stretch)
-	}
-	if cmd.Opacity != nil {
-		fmt.Println(" ", OpacityFlag, *cmd.Opacity)
 	}
 }
 
@@ -56,26 +44,8 @@ func (cmd *ConfigCommand) ValidateFlag(f Flag) error {
 			return err
 		}
 		cmd.Interval = val
-	case AlignmentFlag:
-		val, err := ValidateAlignment(f.Value)
-		if err != nil {
-			return err
-		}
-		cmd.Alignment = val
-	case OpacityFlag:
-		val, err := ValidateOpacity(f.Value)
-		if err != nil {
-			return err
-		}
-		cmd.Opacity = val
-	case StretchFlag:
-		val, err := ValidateStretch(f.Value)
-		if err != nil {
-			return err
-		}
-		cmd.Stretch = val
 	default:
-		return fmt.Errorf("invalid flag for 'run': '%s'", f.Type)
+		return fmt.Errorf("invalid flag for 'config': '%s'", f.Type)
 	}
 	return nil
 }
@@ -103,9 +73,9 @@ func (cmd *ConfigCommand) Execute() error {
 	if err != nil {
 		return err
 	}
-	isEditingConfig := cmd.Profile != nil || cmd.Interval != nil || cmd.Alignment != nil || cmd.Stretch != nil || cmd.Opacity != nil
+	isEditingConfig := cmd.Profile != nil || cmd.Interval != nil
 	if isEditingConfig {
-		config.EditConfig(configPath, cmd.Profile, cmd.Interval, cmd.Alignment, cmd.Stretch, cmd.Opacity)
+		config.EditConfig(configPath, cmd.Profile, cmd.Interval)
 	} else {
 		config.Log(configPath)
 	}

--- a/command_help.go
+++ b/command_help.go
@@ -96,16 +96,16 @@ func (cmd *HelpCommand) Execute() error {
 	fmt.Println("------------------------------------------------------------------------------------")
 	for _, subCmd := range cmd.Commands {
 		switch subCmd.Type() {
-		case RunCommandType:
-			RunHelp(true)
 		case AddCommandType:
 			AddHelp(true)
-		case RemoveCommandType:
-			RemoveHelp(true)
 		case ConfigCommandType:
 			ConfigHelp(true)
 		case HelpCommandType:
 			HelpHelp(true)
+		case RemoveCommandType:
+			RemoveHelp(true)
+		case RunCommandType:
+			RunHelp(true)
 		case VersionCommandType:
 			VersionHelp(true)
 		}
@@ -113,18 +113,18 @@ func (cmd *HelpCommand) Execute() error {
 	}
 	for _, f := range cmd.Flags {
 		switch f.Type {
-		case ProfileFlag:
-			ProfileHelp(true)
-		case IntervalFlag:
-			IntervalHelp(true)
 		case AlignmentFlag:
 			AlignmentHelp(true)
-		case StretchFlag:
-			StretchHelp(true)
+		case IntervalFlag:
+			IntervalHelp(true)
 		case OpacityFlag:
 			OpacityHelp(true)
+		case ProfileFlag:
+			ProfileHelp(true)
 		case RandomFlag:
 			RandomHelp(true)
+		case StretchFlag:
+			StretchHelp(true)
 		}
 		fmt.Println("------------------------------------------------------------------------------------")
 	}

--- a/command_help.go
+++ b/command_help.go
@@ -182,10 +182,6 @@ func RunHelp(verbose bool) {
       |                                |
       | profile: default               | profile: 2
       | interval: 30                   | interval: 5
-      |                                |
-      | alignment: right               | alignment: center
-      | stretch: fill                  | stretch: fill
-      | alignment: 0.1                 | alignment: 0.1
       --------------------------       --------------------------------
      This means that instead of editing the default profile, it will edit the
      2nd profile in Windows Terminal's list. The interval will be 5 minutes
@@ -256,10 +252,6 @@ func AddHelp(verbose bool) {
       |     stretch: uniform
       |   - path: /path/to/the-other/images/dir 
       |     alignment: top
-      |
-      | alignment: right
-      | stretch: fill
-      | alignment: 0.1
       |
       | other fields...
       ----------------------
@@ -332,10 +324,6 @@ func RemoveHelp(verbose bool) {
       |     alignment: center           |     stretch: fill
       |     stretch: fill               |     opacity: 0.1
       |     opacity: 0.1                |
-      |                                 | alignment: right
-      | alignment: right                | stretch: fill
-      | stretch: fill                   | alignment: 0.2
-      | alignment: 0.2                  | 
       |                                 | other fields...
       | other fields...                 -------------------------------
       -------------------------------   
@@ -356,16 +344,10 @@ func ConfigHelp(verbose bool) {
   `, Decorate("Args").Bold(), `: config takes no args
   `, Decorate("Subcommands").Bold(), `: config takes no sub-commands
   `, Decorate("Flags").Bold(), `:
-  1. -a, --alignment [arg]
-         [top, topLeft, topRight, left, center, right, bottomLeft, bottom, bottomRight]
-  2. -o, --opacity   [arg]
-         [any float between 0 and 1 (inclusive)]
-  3. -s, --stretch   [arg]
-         [fill, none, uniform, uniformToFill]
-  4. -p, --profile   [arg]
+  1. -p, --profile   [arg]
          [default, n]
          where n is the list index Windows Terminal uses to identify the profile (starting from 1)
-  5. -i, --interval  [arg]
+  2. -i, --interval  [arg]
          [any positive integer]
          note that this is in minutes.
 
@@ -379,18 +361,15 @@ func ConfigHelp(verbose bool) {
       | profile: default
       | interval: 30
       |
-      | alignment: right
-      | stretch: fill
-      | alignment: 0.1
       --------------------------
 
-  2. tbg config --alignment center
-      replaces the config's "alignment" field with the value "center"
+  2. tbg config --profile 1
+      replaces the config's "profile" field with the value "1"
       --------------------------       --------------------------------
       | paths:                         | paths:
       |   - path: /path/to/images/dir1 |   - path: /path/to/images/dir1
       |                                |
-      | alignment: right               | alignment: center
+      | profile: right                 | profile: 1
       |                                |
       | other fields...                | other fields...
       --------------------------       --------------------------------
@@ -482,9 +461,8 @@ func IntervalHelp(verbose bool) {
      whatever value the \"interval\" field in .tbg.yml will
      be ignored and tbg change images every 30 minutes instead.
 
-  2. tbg edit --interval 30 config /path/to/a/config.yaml
-     this will change the \"interval\" field on the config /path/to/a/config.yaml
-     to 30
+  2. tbg config --interval 10
+     this will change the "interval" field on the config to "10"
 `)
 	}
 }
@@ -506,9 +484,8 @@ func AlignmentHelp(verbose bool) {
      whatever value the "alignment" field in .tbg.yml will
      be ignored and tbg will center the image instead
 
-  2. tbg edit --alignment center config /path/to/a/config.yaml
-     this will change the "alignment" field on the config /path/to/a/config.yaml
-     to "center"
+  2. tbg config --alignment center
+     this will change the "alignment" field on the config to "center"
 `)
 	}
 }
@@ -528,9 +505,8 @@ func StretchHelp(verbose bool) {
      whatever value the \"stretch\" field in .tbg.yml will
      be ignored and tbg will upscale the image to exactly fill the screen instead
 
-  2. tbg edit --stretch fill config /path/to/a/config.yaml
-     this will change the "stretch" field on the config /path/to/a/config.yaml
-     to "fill"
+  2. tbg config --stretch fill
+     this will change the "stretch" field on the config to "fill"
 `)
 	}
 }
@@ -550,9 +526,8 @@ func OpacityHelp(verbose bool) {
      whatever value the "opacity" field in .tbg.yml will
      be ignored and tbg will set the image opacity to 0.5
 
-  2. tbg edit --opacity 0.5 config /path/to/a/config.yaml
-     this will change the "opacity" field on the config /path/to/a/config.yaml
-     to 0.5
+  2. tbg config --opacity 0.5
+     this will change the "opacity" field on the config to "0.5"
 `)
 	}
 }
@@ -568,13 +543,8 @@ func RandomHelp(verbose bool) {
 
   `, Decorate("Examples").Bold(), `:
   1. tbg run --random
-     This will randomize the order of the image collections read
-     from .tbg.yml. It randomizes the order the
-     images in each collection.
-
-     When image collections are exhausted and tbg wraps around, the
-     order of the image collections will be randomized again. This
-     behavior applies to images too.
+     tbg will choose a random image from a random image collection dir every
+     time.
 `)
 	}
 }

--- a/command_remove.go
+++ b/command_remove.go
@@ -21,11 +21,11 @@ func (cmd *RemoveCommand) Debug() {
 	if cmd.Alignment {
 		fmt.Println(" ", AlignmentFlag)
 	}
-	if cmd.Stretch {
-		fmt.Println(" ", StretchFlag)
-	}
 	if cmd.Opacity {
 		fmt.Println(" ", OpacityFlag)
+	}
+	if cmd.Stretch {
+		fmt.Println(" ", StretchFlag)
 	}
 }
 

--- a/command_run.go
+++ b/command_run.go
@@ -19,23 +19,23 @@ func (cmd *RunCommand) Type() CommandType { return RunCommandType }
 func (cmd *RunCommand) Debug() {
 	fmt.Println("Run Command")
 	fmt.Println("Flags:")
-	if cmd.Profile != nil {
-		fmt.Println(" ", ProfileFlag, *cmd.Profile)
+	if cmd.Alignment != nil {
+		fmt.Println(" ", AlignmentFlag, *cmd.Alignment)
 	}
 	if cmd.Interval != nil {
 		fmt.Println(" ", IntervalFlag, *cmd.Interval)
 	}
-	if cmd.Alignment != nil {
-		fmt.Println(" ", AlignmentFlag, *cmd.Alignment)
-	}
-	if cmd.Stretch != nil {
-		fmt.Println(" ", StretchFlag, *cmd.Stretch)
-	}
 	if cmd.Opacity != nil {
 		fmt.Println(" ", OpacityFlag, *cmd.Opacity)
 	}
+	if cmd.Profile != nil {
+		fmt.Println(" ", ProfileFlag, *cmd.Profile)
+	}
 	if cmd.Random != nil {
 		fmt.Println(" ", RandomFlag, *cmd.Random)
+	}
+	if cmd.Stretch != nil {
+		fmt.Println(" ", StretchFlag, *cmd.Stretch)
 	}
 }
 
@@ -48,42 +48,42 @@ func (cmd *RunCommand) ValidateValue(val *string) error {
 
 func (cmd *RunCommand) ValidateFlag(f Flag) error {
 	switch f.Type {
-	case ProfileFlag:
-		val, err := ValidateProfile(f.Value)
-		if err != nil {
-			return err
-		}
-		cmd.Profile = val
-	case IntervalFlag:
-		val, err := ValidateInterval(f.Value)
-		if err != nil {
-			return err
-		}
-		cmd.Interval = val
 	case AlignmentFlag:
 		val, err := ValidateAlignment(f.Value)
 		if err != nil {
 			return err
 		}
 		cmd.Alignment = val
+	case IntervalFlag:
+		val, err := ValidateInterval(f.Value)
+		if err != nil {
+			return err
+		}
+		cmd.Interval = val
 	case OpacityFlag:
 		val, err := ValidateOpacity(f.Value)
 		if err != nil {
 			return err
 		}
 		cmd.Opacity = val
-	case StretchFlag:
-		val, err := ValidateStretch(f.Value)
+	case ProfileFlag:
+		val, err := ValidateProfile(f.Value)
 		if err != nil {
 			return err
 		}
-		cmd.Stretch = val
+		cmd.Profile = val
 	case RandomFlag:
 		val, err := ValidateRandom(f.Value)
 		if err != nil {
 			return err
 		}
 		cmd.Random = val
+	case StretchFlag:
+		val, err := ValidateStretch(f.Value)
+		if err != nil {
+			return err
+		}
+		cmd.Stretch = val
 	default:
 		return fmt.Errorf("invalid flag for 'run': '%s'", f.Type)
 	}

--- a/command_run.go
+++ b/command_run.go
@@ -113,19 +113,19 @@ func (cmd *RunCommand) Execute() error {
 	if err != nil {
 		return err
 	}
-	randomFlag := config.determineExecutionFlags(cmd)
-	backgroundState, err := NewBackgroundState(config, configPath, randomFlag)
+	alignment, stretch, opacity, randomFlag := config.determineExecutionFlags(cmd)
+	backgroundState, err := NewBackgroundState(config, configPath, alignment, stretch, opacity, randomFlag)
 	if err != nil {
 		return err
 	}
 	return backgroundState.Start()
 }
 
-func (config *Config) determineExecutionFlags(cmd *RunCommand) bool {
+func (config *Config) determineExecutionFlags(cmd *RunCommand) (string, string, float32, bool) {
 	config.Profile = Option(cmd.Profile).UnwrapOr(config.Profile)
 	config.Interval = Option(cmd.Interval).UnwrapOr(config.Interval)
-	config.Alignment = Option(cmd.Alignment).UnwrapOr(config.Alignment)
-	config.Stretch = Option(cmd.Stretch).UnwrapOr(config.Stretch)
-	config.Opacity = Option(cmd.Opacity).UnwrapOr(config.Opacity)
-	return Option(cmd.Random).UnwrapOr(false)
+	return Option(cmd.Alignment).UnwrapOr(DefaultAlignment),
+		Option(cmd.Stretch).UnwrapOr(DefaultStretch),
+		Option(cmd.Opacity).UnwrapOr(DefaultOpacity),
+		Option(cmd.Random).UnwrapOr(false)
 }

--- a/config.go
+++ b/config.go
@@ -9,13 +9,16 @@ import (
 	"strings"
 )
 
+const (
+	DefaultAlignment string  = "center"
+	DefaultStretch   string  = "uniform"
+	DefaultOpacity   float32 = 1.0
+)
+
 type Config struct {
-	Paths     []ImagesPath `yaml:"paths"`
-	Interval  uint16       `yaml:"interval"`
-	Profile   string       `yaml:"profile"`
-	Alignment string       `yaml:"alignment"`
-	Stretch   string       `yaml:"stretch"`
-	Opacity   float32      `yaml:"opacity"`
+	Paths    []ImagesPath `yaml:"paths"`
+	Interval uint16       `yaml:"interval"`
+	Profile  string       `yaml:"profile"`
 }
 
 func (cfg *Config) String() string {
@@ -28,10 +31,7 @@ func (cfg *Config) String() string {
 		return ret
 	}(), `
     Interval: `, cfg.Interval, `
-    Profile: `, cfg.Profile, `
-    Alignment: `, cfg.Alignment, `
-    Stretch: `, cfg.Stretch, `
-    Opacity: `, cfg.Opacity,
+    Profile: `, cfg.Profile,
 	)
 }
 
@@ -166,9 +166,6 @@ func (cfg *Config) EditConfig(
 	configPath string,
 	profile *string,
 	interval *uint16,
-	align *string,
-	stretch *string,
-	opacity *float32,
 ) error {
 	// key:val = old:new
 	edited := make(map[string]string, 0)
@@ -179,18 +176,6 @@ func (cfg *Config) EditConfig(
 	if interval != nil {
 		edited[strconv.Itoa(int(cfg.Interval))] = strconv.Itoa(int(*interval))
 		cfg.Interval = *interval
-	}
-	if align != nil {
-		edited[cfg.Alignment] = *align
-		cfg.Alignment = *align
-	}
-	if stretch != nil {
-		edited[cfg.Stretch] = *stretch
-		cfg.Stretch = *stretch
-	}
-	if opacity != nil {
-		edited[strconv.FormatFloat(float64(cfg.Opacity), 'f', -1, 64)] = strconv.FormatFloat(float64(*opacity), 'f', -1, 64)
-		cfg.Opacity = *opacity
 	}
 	template := NewConfigTemplate(configPath)
 	template.YamlContents, _ = yaml.Marshal(cfg)
@@ -263,9 +248,6 @@ func (cfg *Config) Log(configPath string) ConfigLogger {
 	}
 	fmt.Printf("|\n%-25s%s\n", "| profile:", cfg.Profile)
 	fmt.Printf("%-25s%d\n", "| interval:", cfg.Interval)
-	fmt.Printf("%-25s%s\n", "| alignment:", cfg.Alignment)
-	fmt.Printf("%-25s%s\n", "| stretch:", cfg.Stretch)
-	fmt.Printf("%-25s%f\n", "| opacity:", cfg.Opacity)
 	fmt.Println("------------------------------------------------------------------------------------")
 	return ConfigLogger{}
 }

--- a/config.go
+++ b/config.go
@@ -11,8 +11,8 @@ import (
 
 const (
 	DefaultAlignment string  = "center"
-	DefaultStretch   string  = "uniform"
 	DefaultOpacity   float32 = 1.0
+	DefaultStretch   string  = "uniform"
 )
 
 type Config struct {
@@ -190,8 +190,8 @@ func (cfg *Config) EditConfig(
 type ImagesPath struct {
 	Path      string   `yaml:"path"`
 	Alignment *string  `yaml:"alignment,omitempty"`
-	Stretch   *string  `yaml:"stretch,omitempty"`
 	Opacity   *float32 `yaml:"opacity,omitempty"`
+	Stretch   *string  `yaml:"stretch,omitempty"`
 }
 
 func (path *ImagesPath) String() string {

--- a/config_template.go
+++ b/config_template.go
@@ -31,9 +31,9 @@ func NewConfigTemplate(path string) *ConfigTemplate {
 		paths = fmt.Sprintf(`
 paths:
 - path: %s
-  # alignment: right # uncomment this if you want to override the alignment field below
-  # stretch: fill    # uncomment this if you want to override the stretch field below
-  # opacity: 0.25    # uncomment this if you want to override the opacity field below
+  # alignment: right # optional (default: center)
+  # stretch: fill    # optional (default: uniform)
+  # opacity: 0.25    # optional (default: 1.0)
 `,
 			picturesDir)
 	}
@@ -59,30 +59,23 @@ opacity: 1.0
 # Fields:
 #   paths: list of image collection paths
 #     - path: directory that contain images
-#       alignment: optional alignment value applied only to this path.
-#                  uses default alignment (see "alignment" field) if not specified
-#       stretch:   optional stretch value applied only to this path
-#                  uses default stretch (see "stretch" field) if not specified
-#       opacity:   poptional opacity value applied only to this path
-#                  uses default opacity (see "opacity" field) if not specified
+#       alignment: (optional) image alignment in Windows Terminal
+#                  valid values: topLeft, top, topRight, left, center, right, bottomLeft, bottom, bottomRight
+#                  https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-appearance#background-image-alignment
+#
+#       opacity:   (optional) image opacity of background images in Windows Terminal
+#                  valid values: 0.0 - 1.0 (inclusive)
+#                  https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-appearance#background-image-opacity
+#
+#       stretch:   (optional) image stretch in Windows Terminal
+#                  valid values: fill, none, uniform, uniformToFill
+#                  https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-appearance#background-image-stretch-mode 
 #
 #   profile: profile profile in Windows Terminal
 #      valid values: default, 0, 1, ..., n
 #      https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-general
 #
 #   interval: time in minutes between each image change
-#
-#   alignment: image alignment in Windows Terminal
-#     valid values: topLeft, top, topRight, left, center, right, bottomLeft, bottom, bottomRight
-#     https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-appearance#background-image-alignment
-#
-#   opacity: image opacity of background images in Windows Terminal
-#     valid values: 0.0 - 1.0 (inclusive)
-#     https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-appearance#background-image-opacity
-#
-#   stretch: image stretch in Windows Terminal
-#     valid values: fill, none, uniform, uniformToFill
-#     https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-appearance#background-image-stretch-mode 
 #------------------------------------------
 `),
 	}

--- a/docs/add_command_usage.md
+++ b/docs/add_command_usage.md
@@ -30,11 +30,8 @@ Let's say this is `.tbg.yml`:
 ```yml
 paths: []
 
-alignment: center
-stretch: uniform
-opacity: 0.5
-
-other fields...
+interval: 30
+profile: default
 ```
 If we run:
 ```bash
@@ -46,11 +43,8 @@ like this:
 paths:
 - path: path/to/images/dir1
 
-alignment: center
-stretch: uniform
-opacity: 0.5
-
-other fields...
+interval: 30
+profile: default
 ```
 ### Adding a path with options
 Let's continue with our config and run this:
@@ -66,11 +60,8 @@ paths:
   stretch: fill
   opacity: 0.5
 
-alignment: center
-stretch: uniform
-opacity: 0.5
-
-other fields...
+interval: 30
+profile: default
 ```
 Let's add another one:
 ```bash
@@ -91,7 +82,7 @@ stretch: uniform
 opacity: 0.5
 ```
 Options that were not specified will inherit their respective default value
-(`stretch` and `opacity` in this example)
+(`stretch` and `opacity` will be `center` and `1.0` in this example)
 
 #### Adding an option to an existing path
 Let's continue with our config and run this:
@@ -107,9 +98,8 @@ paths:
   alignment: right
   stretch: fill # this path only had alignment in the example above
 
-alignment: center
-stretch: uniform
-opacity: 0.5
+interval: 30
+profile: default
 ```
 Let's fill assign the opacity too
 ```bash
@@ -123,9 +113,8 @@ paths:
   stretch: fill
   opacity: 0.25
 
-alignment: center
-stretch: uniform
-opacity: 0.5
+interval: 30
+profile: default
 ```
 #### Changing an option of an existing path
 Let's change the opacity and stretch:
@@ -142,9 +131,8 @@ paths:
   stretch: none # used to be fill
   opacity: 1    # used to be 0.25
 
-alignment: center
-stretch: uniform
-opacity: 0.5
+interval: 30
+profile: default
 ```
 Let's change the alignment too
 ```bash
@@ -158,7 +146,6 @@ paths:
   stretch: none 
   opacity: 1
 
-alignment: center
-stretch: uniform
-opacity: 0.5
+interval: 30
+profile: default
 ```

--- a/docs/config_command_usage.md
+++ b/docs/config_command_usage.md
@@ -21,15 +21,6 @@ based on flags passed to it.
 2. `--interval [arg]`
     - args: `topRight`, `top`, `topLeft`, `left`, `center`, `right`, `bottomLeft`, `bottom`, `bottomRight`
     - edits: `interval`
-3. `--alignment [arg]`
-    - args: `topRight`, `top`, `topLeft`, `left`, `center`, `right`, `bottomLeft`, `bottom`, `bottomRight`
-    - edits: `alignment` (the top level alignment, not the per path alignment)
-4. `--stretch [arg]`
-    - args: `none`, `fill`, `uniform`, `uniformToFill`
-    - edits: `stretch` (top level stretch)
-5. `--opacity [arg]`
-    - args: any float between 0 and 1 (inclusive)
-    - edits: `opacity` (top level opacity)
 
 # Usage
 #### Printing config
@@ -50,16 +41,13 @@ Output on console should look something like this
 |
 | profile:               default
 | interval:              30
-| alignment:             center
-| stretch:               uniform
-| opacity:               0.100000
 ------------------------------------------------------------------------------------
 ```
 
 #### Editing fields of config
 To edit fields of config, specify any fields you want to edit with flags like this this:
 ```bash
-tbg config --alignment topRight
+tbg config --profile 1
 ```
 ```bash
 ------------------------------------------------------------------------------------
@@ -71,16 +59,13 @@ tbg config --alignment topRight
 |   stretch: fill
 |   opacity: 0.250000
 |
-| profile:               default
+| profile:               1 # used to be default
 | interval:              30
-| alignment:             topRight # used to be center in the above example
-| stretch:               uniform
-| opacity:               0.100000
 ------------------------------------------------------------------------------------
 ```
-You can do this with the other four fields as well
+You can do this with interval as well
 ```bash
-tbg config --profile 1 --interval 5 --stretch fill --opacity 0.35
+tbg config --interval 5
 ```
 ```bash
 ------------------------------------------------------------------------------------
@@ -92,10 +77,7 @@ tbg config --profile 1 --interval 5 --stretch fill --opacity 0.35
 |   stretch: fill
 |   opacity: 0.250000
 |
-| profile:               1        # used to be default
-| interval:              5        # used to be 30
-| alignment:             topRight
-| stretch:               fill     # used to be uniform
-| opacity:               0.350000 # used to be 0.100000
+| profile:               1        
+| interval:              5 # used to be 30
 ------------------------------------------------------------------------------------
 ```

--- a/docs/remove_command_usage.md
+++ b/docs/remove_command_usage.md
@@ -29,11 +29,8 @@ Let's say this is the `.tbg.yml`:
 paths:
 - path: path/to/images/dir1
 
-alignment: center
-stretch: uniform
-opacity: 0.5
-
-other fields...
+interval: 30
+profile: default
 ```
 If we run:
 ```bash
@@ -44,11 +41,8 @@ field like this:
 ```yml
 paths: []
 
-alignment: center
-stretch: uniform
-opacity: 0.5
-
-other fields...
+interval: 30
+profile: default
 ```
 ### Removing options from a path
 Let's use this config
@@ -59,11 +53,8 @@ paths:
   stretch: fill
   opacity: 0.5
 
-alignment: center
-stretch: uniform
-opacity: 0.5
-
-other fields...
+interval: 30
+profile: default
 ```
 Let's "remove" the alignment flag of `path/to/images/dir1`:
 ```bash
@@ -75,13 +66,10 @@ paths:
   stretch: fill
   opacity: 0.5
 
-alignment: center
-stretch: uniform
-opacity: 0.5
-
-other fields...
+interval: 30
+profile: default
 ```
-The path will now inherit the top level `alignment` value (`center`).
+The path will now inherit the default `alignment` value (`center`).
 Let's remove stretch next.
 ```bash
 tbg remove path/to/images/dir1 --stretch
@@ -92,13 +80,10 @@ paths:
   stretch: fill
   opacity: 0.5
 
-alignment: center
-stretch: uniform
-opacity: 0.5
-
-other fields...
+interval: 30
+profile: default
 ```
-The path will now inherit the top level `stretch` value (`uniform`).
+The path will now inherit the default `stretch` value (`uniform`).
 
 Now let's see if we remove opacity:
 ```bash
@@ -108,11 +93,8 @@ tbg remove path/to/images/dir1 --opacity
 paths:
 - path: path/to/images/dir1
 
-profile: default
 interval: 30
-
-default_alignment: center
-default_stretch: uniform
-default_opacity: 0.1
+profile: default
 ```
-Now all the path will inehrit the top level alignment, stretch, and opacity.
+Now all the path will inehrit the default alignment (`center`), stretch
+(`uniform`), and opacity (`1.0`).

--- a/docs/run_command_usage.md
+++ b/docs/run_command_usage.md
@@ -7,7 +7,7 @@
 - [Usage](#usage)
     - [Normal Execution, key events, and path specific options](#normal-execution)
     - [Overriding `profile` and `interval` fields](#overriding-profile-and-interval-fields)
-    - [Overriding default option fields](#overriding-default-option-fields)
+    - [Overriding default values](#overriding-default-values)
 ---
 
 # `tbg run`
@@ -72,7 +72,7 @@ will use the flags instead of that or the default options fields.
 The order of importance is:
 1. flags (`--alignment`, `--opacity`, `--stretch`)
 2. per path options in config
-3. default options fields in config
+3. default values
 
 For an example, see [overriding default flags walkthrough](#overriding-default-option-fields)
 
@@ -95,27 +95,22 @@ paths:
 
 profile: default
 interval: 30
-
-alignment: center
-stretch: fill
-opacity: 0.1
 ```
 This just means that when we do `tbg run`, we want to change the background
 image of the **default** *Windows Terminal* profile every **30 minutes**. The
 first few images will be from `path/to/dir1`. The image will be at the
-**center**, **fill** the entire screen without regard of the original aspect
-ratio, with an opacity of **10%**. 
+**center**, with the stretch **uniform** to fill the screen while keeping
+aspect ratio, with an opacity of **100%**. 
 
 When I press `n`, it goes to the next image without waiting for 30 minutes. I
 can go back by pressing `p`.
 
 When I press `N`, it goes to the next image collection dir. This means we are
 now in `path/to/dir2`. This path has flags specific to it so these values will
-be used instead of the default flag fields. This means instead of the image
-being at the **center**, it will be at the **right**. - Instead of having an
-opacity of **10%**, it the images will have **35%** opacity. However, since
-stretch is the same, it will still **fill** the screen without regard of the
-orignal aspect ratio.
+be used instead of the defaults. This means instead of the image being at the
+**center**, it will be at the **right**. - Instead of having an opacity of
+**10%**, it the images will have **35%** opacity. The image will **fill** the
+screen, without regard for aspect ratio.
 
 When I press `P`, it goes back to the previous image collection dir
 (`path/to/dir1`). If i press `P` again, it will wrap around and go to the last
@@ -137,10 +132,6 @@ paths:
 
 profile: default
 interval: 30
-
-alignment: center
-stretch: fill
-opacity: 0.1
 ```
 
 The `--profile` and `--interval` flags will override the values in the config.
@@ -149,9 +140,9 @@ the `default` profile every 30 minutes, it will change the background image of
 the first profile under `list` field in `settings.json` every 5 minutes instead
 
 ---
-### Overriding default option fields
-This will delve on overriding default options fields on the config using
-flags. This will also override the per-path options.
+### Overriding default values
+This will delve on overriding default values on the config using flags. This
+will also override the per-path options.
 
 Let's use this config:
 ```yml
@@ -164,10 +155,6 @@ paths:
 
 profile: default
 interval: 30
-
-alignment: center
-stretch: fill
-opacity: 0.1
 ```
 Let's do:
 ```bash
@@ -175,9 +162,9 @@ tbg run --alignment right --opacity 0.35 --stretch none
 ```
 
 The `--alignment`, `--opacity`, and `--stretch` flags will override the values
-in `.tbg.yml`. This means instead of `path/to/dir`'s images being centered,
-filling entire screen at 10% opacity, the images will be on the right, with no
-upscaling/downscaling, at 35% opacity.
+in `.tbg.yml`. This means instead of `path/to/dir1`'s images being centered,
+filling entire screen while keeping aspect ratio at 100% opacity, the images
+will be on the right, with no scaling, at 35% opacity.
 
 Notice that `path/to/dir2` has options that should override the default options
 fields. However, since we specified `--alignment right --opacity 0.35 --stretch

--- a/docs/tbg.yml.md
+++ b/docs/tbg.yml.md
@@ -15,45 +15,34 @@ on initial execution. This is what it should look like:
 
 paths:
 - path: path/to/images/dir
-  # alignment: right # uncomment to override the alignment field for this specific image path
-  # stretch: fill    # override stretch
-  # opacity: 0.25    # override opacity
+  # alignment: right # override default alignment of center
+  # stretch: fill    # override default stretch of uniform
+  # opacity: 0.25    # override default opacity of 1.0
 
 profile: default
 interval: 30
-
-alignment: center
-stretch: uniform
-opacity: 0.1
 
 #------------------------------------------
 # Fields:
 #   paths: list of image collection paths
 #     - path: directory that contain images
-#       alignment: optional alignment value applied only to this path.
-#                  uses default alignment (see "alignment" field) if not specified
-#       stretch:   optional stretch value applied only to this path
-#                  uses default stretch (see "stretch" field) if not specified
-#       opacity:   poptional opacity value applied only to this path
-#                  uses default opacity (see "opacity" field) if not specified
+#       alignment: (optional) image alignment in Windows Terminal
+#                  valid values: topLeft, top, topRight, left, center, right, bottomLeft, bottom, bottomRight
+#                  https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-appearance#background-image-alignment
+#
+#       opacity:   (optional) image opacity of background images in Windows Terminal
+#                  valid values: 0.0 - 1.0 (inclusive)
+#                  https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-appearance#background-image-opacity
+#
+#       stretch:   (optional) image stretch in Windows Terminal
+#                  valid values: fill, none, uniform, uniformToFill
+#                  https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-appearance#background-image-stretch-mode 
 #
 #   profile: profile profile in Windows Terminal
 #      valid values: default, 0, 1, ..., n
 #      https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-general
 #
 #   interval: time in minutes between each image change
-#
-#   alignment: image alignment in Windows Terminal
-#     valid values: topLeft, top, topRight, left, center, right, bottomLeft, bottom, bottomRight
-#     https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-appearance#background-image-alignment
-#
-#   opacity: image opacity of background images in Windows Terminal
-#     valid values: 0.0 - 1.0 (inclusive)
-#     https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-appearance#background-image-opacity
-#
-#   stretch: image stretch in Windows Terminal
-#     valid values: fill, none, uniform, uniformToFill
-#     https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-appearance#background-image-stretch-mode 
 #------------------------------------------
 ```
 ## Fields
@@ -75,26 +64,26 @@ Although you can edit the fields in the config directly, it is recommended to us
         - `- path: path/to/dir1` 
         - ```yaml
             - path: path/to/dir2
-              alignment: center      # optional
-              stretch: uniformToFill # optional
-              opacity: 1.0           # optional
+              alignment: center # optional
+              stretch: uniform  # optional
+              opacity: 1.0      # optional
     - paths containing images used in changing the background image of Windows Terminal
     - Each path can override the default fields below.
     - default values for per-path options if not specified are:
         - `alignment: center`
-        - `stretch: uniformToFill`
+        - `stretch: uniform`
         - `opacity: 1.0`
-4. **alignment**
-    - ( args ): `top`, `topLeft`, `topRight`, `left`, `center`, `right`, `bottom`, `bottomLeft`, `bottomRight` 
-    - image alignment in Windows Terminal.
-    - Can be overriden on a per-path basis
-5. `stretch` 
-    - *args*: `uniform`, `fill`, `uniformToFill`, `none` 
-    - image stretch in Windows Terminal. Can be overriden on a per-path basis |
-6. `opacity` 
-    - *args*: inclusive range between `0` and `1` 
-    - image opacity of background images in Windows Terminal.
-    - Can be overriden on a per-path basis
+    1. **alignment**
+        - *args*: `top`, `topLeft`, `topRight`, `left`, `center`, `right`, `bottom`, `bottomLeft`, `bottomRight` 
+        - image alignment in Windows Terminal.
+        - Can be overriden on a per-path basis
+    2. `stretch` 
+        - *args*: `uniform`, `fill`, `uniformToFill`, `none` 
+        - image stretch in Windows Terminal. Can be overriden on a per-path basis |
+    3. `opacity` 
+        - *args*: inclusive range between `0` and `1` 
+        - image opacity of background images in Windows Terminal.
+        - Can be overriden on a per-path basis
 
 For the default flag fields (`alignment`, `stretch`, and `opacity`), see
 [Mircrosoft's documentation](https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-appearance#background-images-and-icons)

--- a/flag.go
+++ b/flag.go
@@ -8,30 +8,30 @@ type FlagType uint8
 
 const (
 	NoFlag FlagType = iota
-	ProfileFlag
-	IntervalFlag
 	AlignmentFlag
+	IntervalFlag
 	OpacityFlag
-	StretchFlag
+	ProfileFlag
 	RandomFlag
+	StretchFlag
 )
 
 func (f FlagType) String() string {
 	switch f {
-	case NoFlag:
-		return "none"
-	case ProfileFlag:
-		return "--profile"
-	case IntervalFlag:
-		return "--interval"
 	case AlignmentFlag:
 		return "--alignment"
+	case IntervalFlag:
+		return "--interval"
+	case NoFlag:
+		return "none"
 	case OpacityFlag:
 		return "--opacity"
-	case StretchFlag:
-		return "--stretch"
+	case ProfileFlag:
+		return "--profile"
 	case RandomFlag:
 		return "--random"
+	case StretchFlag:
+		return "--stretch"
 	default:
 		return "unknown"
 	}
@@ -44,18 +44,18 @@ type Flag struct {
 
 func ToFlag(s string) (*Flag, error) {
 	switch s {
-	case "--profile", "-p":
-		return &Flag{Type: ProfileFlag}, nil
-	case "--interval", "-i":
-		return &Flag{Type: IntervalFlag}, nil
 	case "--alignment", "-a":
 		return &Flag{Type: AlignmentFlag}, nil
+	case "--interval", "-i":
+		return &Flag{Type: IntervalFlag}, nil
 	case "--opacity", "-o":
 		return &Flag{Type: OpacityFlag}, nil
-	case "--stretch", "-s":
-		return &Flag{Type: StretchFlag}, nil
+	case "--profile", "-p":
+		return &Flag{Type: ProfileFlag}, nil
 	case "--random", "-r":
 		return &Flag{Type: RandomFlag}, nil
+	case "--stretch", "-s":
+		return &Flag{Type: StretchFlag}, nil
 	default:
 		return nil, fmt.Errorf("unknown flag: %s", s)
 	}

--- a/flag_validators.go
+++ b/flag_validators.go
@@ -5,18 +5,16 @@ import (
 	"strconv"
 )
 
-func ValidateProfile(val *string) (*string, error) {
+func ValidateAlignment(val *string) (*string, error) {
 	if val == nil {
-		return nil, fmt.Errorf("--profile must have an argument. got none")
+		return nil, fmt.Errorf("--interval must have an argument. got none")
 	}
-	if *val == "default" {
+	switch *val {
+	case "topLeft", "top", "topRight", "left", "center", "right", "bottomLeft", "bottom", "bottomRight":
 		return val, nil
+	default:
+		return nil, fmt.Errorf("invalid arg '%s' for --alignment: unknown alignment", *val)
 	}
-	_, err := strconv.Atoi(*val)
-	if err != nil {
-		return nil, fmt.Errorf("invalid arg '%s' for --profile: must be a number. %s", *val, err.Error())
-	}
-	return val, nil
 }
 
 func ValidateInterval(val *string) (*uint16, error) {
@@ -34,18 +32,6 @@ func ValidateInterval(val *string) (*uint16, error) {
 	return &ret, nil
 }
 
-func ValidateAlignment(val *string) (*string, error) {
-	if val == nil {
-		return nil, fmt.Errorf("--interval must have an argument. got none")
-	}
-	switch *val {
-	case "topLeft", "top", "topRight", "left", "center", "right", "bottomLeft", "bottom", "bottomRight":
-		return val, nil
-	default:
-		return nil, fmt.Errorf("invalid arg '%s' for --alignment: unknown alignment", *val)
-	}
-}
-
 func ValidateOpacity(val *string) (*float32, error) {
 	if val == nil {
 		return nil, fmt.Errorf("--interval must have an argument. got none")
@@ -61,16 +47,18 @@ func ValidateOpacity(val *string) (*float32, error) {
 	return &ret, nil
 }
 
-func ValidateStretch(val *string) (*string, error) {
+func ValidateProfile(val *string) (*string, error) {
 	if val == nil {
-		return nil, fmt.Errorf("--stretch must have an argument. got none")
+		return nil, fmt.Errorf("--profile must have an argument. got none")
 	}
-	switch *val {
-	case "none", "fill", "uniform", "uniformToFill":
+	if *val == "default" {
 		return val, nil
-	default:
-		return nil, fmt.Errorf("invalid arg '%s' for --stretch: unknown stretch", *val)
 	}
+	_, err := strconv.Atoi(*val)
+	if err != nil {
+		return nil, fmt.Errorf("invalid arg '%s' for --profile: must be a number. %s", *val, err.Error())
+	}
+	return val, nil
 }
 
 func ValidateRandom(val *string) (*bool, error) {
@@ -83,5 +71,17 @@ func ValidateRandom(val *string) (*bool, error) {
 		return &ret, nil
 	default:
 		return nil, fmt.Errorf("'--random' flag does not take any arguments. got '%s'", *val)
+	}
+}
+
+func ValidateStretch(val *string) (*string, error) {
+	if val == nil {
+		return nil, fmt.Errorf("--stretch must have an argument. got none")
+	}
+	switch *val {
+	case "none", "fill", "uniform", "uniformToFill":
+		return val, nil
+	default:
+		return nil, fmt.Errorf("invalid arg '%s' for --stretch: unknown stretch", *val)
 	}
 }

--- a/style.go
+++ b/style.go
@@ -13,9 +13,9 @@ const (
 	Bold      AnsiCode = "\033[1m"
 	Italic    AnsiCode = "\033[3m"
 	Underline AnsiCode = "\033[4m"
+	Blue      AnsiCode = "\033[34m"
 	Red       AnsiCode = "\033[31m"
 	Yellow    AnsiCode = "\033[33m"
-	Blue      AnsiCode = "\033[34m"
 )
 
 type Styled string

--- a/tbg.go
+++ b/tbg.go
@@ -41,7 +41,7 @@ type TbgEvents struct {
 	Error        chan error
 }
 
-func NewBackgroundState(config *Config, configPath string, randomFlag bool) (*TbgState, error) {
+func NewBackgroundState(config *Config, configPath string, alignment string, stretch string, opacity float32, randomFlag bool) (*TbgState, error) {
 	wtSettings, err := NewWTSettings()
 	if err != nil {
 		return nil, err
@@ -53,9 +53,9 @@ func NewBackgroundState(config *Config, configPath string, randomFlag bool) (*Tb
 		PathIndex:            0,
 		Config:               config,
 		ConfigPath:           configPath,
-		CurrentPathAlignment: config.Alignment,
-		CurrentPathStretch:   config.Stretch,
-		CurrentPathOpacity:   config.Opacity,
+		CurrentPathAlignment: alignment,
+		CurrentPathStretch:   stretch,
+		CurrentPathOpacity:   opacity,
 		Random:               randomFlag,
 		Events: &TbgEvents{
 			Done:         make(chan struct{}),
@@ -103,9 +103,9 @@ func (tbg *TbgState) Init() error {
 
 func (tbg *TbgState) UpdateCurrentPathState() error {
 	currentPath := tbg.Config.Paths[tbg.PathIndex]
-	tbg.CurrentPathAlignment = Option(currentPath.Alignment).UnwrapOr(tbg.Config.Alignment)
-	tbg.CurrentPathStretch = Option(currentPath.Stretch).UnwrapOr(tbg.Config.Stretch)
-	tbg.CurrentPathOpacity = Option(currentPath.Opacity).UnwrapOr(tbg.Config.Opacity)
+	tbg.CurrentPathAlignment = Option(currentPath.Alignment).UnwrapOr(DefaultAlignment)
+	tbg.CurrentPathStretch = Option(currentPath.Stretch).UnwrapOr(DefaultStretch)
+	tbg.CurrentPathOpacity = Option(currentPath.Opacity).UnwrapOr(DefaultOpacity)
 	var err error
 	tbg.Images, err = currentPath.Images()
 	ShuffleFrom(0, tbg.Images)
@@ -330,7 +330,7 @@ func invalidCommandForRandom(msg string, isRandom bool) string {
 	if isRandom {
 		return cursorUp
 	} else {
-		return `p: [p]revious image`
+		return msg
 	}
 
 }


### PR DESCRIPTION
## Changes
1. no more top level `alignment`, `opacity`, and `stretch` fields in the config. user cannot define the default values anymore. the defaults will be constant:
   | field     | default value |
   |-----------|---------------|
   | alignment | center        |
   | opacity   | 1.0           |
   | stretch   | uniform       |
2. update `config` command to not be able to edit `alignment`, `opacity`, and `stretch` fields since those do not exist anymore
3. update docs and help messages

---
no functionality changes tho. everything works as expected