### PR TITLE
Feat/http server and server commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [Config](#config)
     - [Fields](#fields)
 - [Commands](#commands)
+    - [Server Commands](#server-commands)
     - [Flags](#flags)
 - [Credits](#credits)
 
@@ -47,20 +48,30 @@ git clone https://github.com/saltkid/tbg.git && cd tbg && go mod tidy && go buil
 ```
 
 # [Usage](https://github.com/saltkid/tbg/blob/main/docs/run_command_usage.md)
+## Automatically change background image at a set interval
 ```
 tbg run
 ```
-This will target Windows Terminal's default profile, changing the background
-image every 30 minutes, choosing an random image from the specified `paths` in
-`.tbg.yml`. The default image properties are:
-1. alignment: `center`
-2. opacity: `1.0`
-3. stretch: `uniformToFill`
+This will start the **tbg** server. This will target Windows Terminal's default
+profile, changing the background image every 30 minutes, choosing an random
+image from the specified `paths` in `.tbg.yml`. See [fields](#fields) for more
+information about images paths. The default image properties are:
 
-On initial execution of **tbg**, it will create a [default config](#config)
+| image property | default value  |
+|----------------|----------------|
+| alignment      | `center`       |
+| opacity        | `1.0`          |
+| stretch        | `uniformToFill`|
+
+On initial execution of `tbg run`, it will create a [default config](#config)
 (`.tbg.yml`) in the same directory as the executable. You can edit this
 manually **or** use [tbg commands](#commands) to edit these with input
 validation
+
+### tbg server
+`tbg run` starts the **tbg** http server where POST requests can be made to
+trigger certain actions. These post requests can be made through [tbg server
+commands](#server-commands) for convenience
 
 ## Interactive Commands
 While **tbg** is running, it takes in optional user input through key presses.
@@ -68,7 +79,6 @@ While **tbg** is running, it takes in optional user input through key presses.
 - `c`: shows the available commands
 - `n`: goes to the next image (randomly chosen)
 
-See [fields](#fields) for more information about images paths.
 
 # Config
 **tbg** uses `.tbg.yml` to edit the `settings.json` *Windows Terminal* uses.
@@ -97,6 +107,9 @@ command to edit the file.
               opacity: 1.0           # optional
 
 # Commands
+```zsh
+tbg <command-name>
+```
 For a more detailed explanation on each command, follow the command name links
 
 1. [run](https://github.com/saltkid/tbg/blob/main/docs/run_command_usage.md) 
@@ -127,6 +140,19 @@ For a more detailed explanation on each command, follow the command name links
     - Prints the general help message when no arg is given
     - Prints the help message/s of command/s and/or flag/s if specified
     - *args*: no arg, or any command or any flag (can be multiple)
+
+## Server Commands
+These commands only work when there's a **tbg** server active. Usage is the
+same as other commands.
+1. next-image
+    - triggers an image change
+    - curl equivalent: `curl -X POST localhost:9545/next-image`
+2. quit
+    - stops the server
+    - curl equivalent: `curl -X POST localhost:9545/quit`
+
+*Tip: you can assign these commands to keybinds in Windows Terminal Settings*
+
 ## Flags
 Flags behave differently based on the command so for more detailed explanation,
 go to the documentation of the command instead.

--- a/command.go
+++ b/command.go
@@ -31,6 +31,10 @@ func ToCommand(s string) (Command, error) {
 		return new(HelpCommand), nil
 	case "version":
 		return new(VersionCommand), nil
+	case "next-image":
+		return new(NextImageCommand), nil
+	case "quit":
+		return new(QuitCommand), nil
 	default:
 		return nil, fmt.Errorf("unknown command: %s", s)
 	}
@@ -46,6 +50,8 @@ const (
 	RemoveCommandType
 	HelpCommandType
 	VersionCommandType
+	NextImageCommandType
+	QuitCommandType
 )
 
 func (c CommandType) String() string {
@@ -64,6 +70,10 @@ func (c CommandType) String() string {
 		return "help"
 	case VersionCommandType:
 		return "version"
+	case NextImageCommandType:
+		return "next-image"
+	case QuitCommandType:
+		return "quit"
 	default:
 		return fmt.Sprintf("UNKNOWN COMMAND '%d'", c)
 	}
@@ -87,6 +97,10 @@ func (c CommandType) ToCommand() Command {
 		return new(HelpCommand)
 	case VersionCommandType:
 		return new(VersionCommand)
+	case NextImageCommandType:
+		return new(NextImageCommand)
+	case QuitCommandType:
+		return new(QuitCommand)
 	default: // case: NoCommandType
 		return nil
 	}

--- a/command_add.go
+++ b/command_add.go
@@ -16,7 +16,7 @@ type AddCommand struct {
 func (cmd *AddCommand) Type() CommandType { return AddCommandType }
 
 func (r *AddCommand) Debug() {
-	fmt.Println("Config Command:", r.Type())
+	fmt.Println("Add Command:", r.Type())
 	fmt.Println("Path:", r.Path)
 	fmt.Println("Flags:")
 	if r.Alignment != nil {

--- a/command_help.go
+++ b/command_help.go
@@ -52,13 +52,13 @@ func (cmd *HelpCommand) Execute() error {
 			Decorate("Terminal Background Gallery").Italic(),
 		)
 		fmt.Printf("%-30s%s\n", "",
-			fmt.Sprintf("%s (%s) allows the user to have and manage multiple background",
+			fmt.Sprintf("%s (%s) allows the user to cycle through multiple background",
 				Decorate("tbg").Bold(),
 				Decorate("teabag").Italic(),
 			),
 		)
 		fmt.Printf("%-30s%s\n", "",
-			"images, that rotate at a set amount of time, for Windows Terminal.",
+			"images at a set interval for Windows Terminal.",
 		)
 		fmt.Printf("%-37s%s\n",
 			Decorate("Version").Bold().Underline(),
@@ -66,12 +66,14 @@ func (cmd *HelpCommand) Execute() error {
 		)
 		fmt.Printf("\n%-37s%s\n",
 			Decorate("Usage").Bold().Underline(),
-			Decorate("tbg run").Italic(),
+			Decorate("tbg [command] <flags>").Italic(),
 		)
 		fmt.Printf("\n%s:\n",
 			Decorate("Commands").Bold().Underline(),
 		)
 		RunHelp(false)
+		NextImageHelp(false)
+		QuitHelp(false)
 		AddHelp(false)
 		RemoveHelp(false)
 		ConfigHelp(false)
@@ -107,6 +109,10 @@ func (cmd *HelpCommand) Execute() error {
 			RunHelp(true)
 		case VersionCommandType:
 			VersionHelp(true)
+		case NextImageCommandType:
+			NextImageHelp(true)
+		case QuitCommandType:
+			QuitHelp(true)
 		}
 		fmt.Println("------------------------------------------------------------------------------------")
 	}
@@ -131,7 +137,7 @@ func (cmd *HelpCommand) Execute() error {
 func RunHelp(verbose bool) {
 	fmt.Printf("%-33s%s",
 		Decorate("  run").Bold(),
-		"reads the used config and edits Windows Terminal's settings.json to change background images\n",
+		"Starts the tbg server that changes the background image at an interval\n",
 	)
 	if verbose {
 		fmt.Print(`
@@ -401,16 +407,45 @@ func HelpHelp(verbose bool) {
 
 func VersionHelp(verbose bool) {
 	fmt.Printf("%-33s%s",
-		Decorate("  -v, --version").Bold(),
+		Decorate("  version").Bold(),
 		"Prints the version of tbg\n",
 	)
 	if verbose {
 		fmt.Print(`
-  `, Decorate("Args").Bold(), `: --version does not take args
+  `, Decorate("Args").Bold(), `: version does not take args
 
   `, Decorate("Examples").Bold(), `:
   1. tbg version
-     Prints the version of tbg
+`)
+	}
+}
+
+func NextImageHelp(verbose bool) {
+	fmt.Printf("%-33s%s",
+		Decorate("  next-image").Bold(),
+		"Triggers an image change on the currently running tbg server\n",
+	)
+	if verbose {
+		fmt.Print(`
+  `, Decorate("Args").Bold(), `: next-image does not take args
+
+  `, Decorate("Examples").Bold(), `:
+  1. tbg next-image
+`)
+	}
+}
+
+func QuitHelp(verbose bool) {
+	fmt.Printf("%-33s%s",
+		Decorate("  quit").Bold(),
+		"Stops the currently running tbg server\n",
+	)
+	if verbose {
+		fmt.Print(`
+  `, Decorate("Args").Bold(), `: quit does not take args
+
+  `, Decorate("Examples").Bold(), `:
+  1. tbg quit
 `)
 	}
 }

--- a/command_next_image.go
+++ b/command_next_image.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type NextImageCommand struct{}
+
+func (cmd *NextImageCommand) Type() CommandType { return NextImageCommandType }
+
+func (r *NextImageCommand) Debug() {
+	fmt.Println("Next Image Command:", r.Type())
+}
+
+func (cmd *NextImageCommand) ValidateValue(val *string) error {
+	if val == nil || *val == "" {
+		return nil
+	}
+	return fmt.Errorf("'next-image' takes no args. got: '%s'", *val)
+}
+
+func (cmd *NextImageCommand) ValidateFlag(f Flag) error {
+	return fmt.Errorf("'next-image' takes no flags. got: '%s'", f.Type)
+}
+
+func (cmd *NextImageCommand) ValidateSubCommand(sc Command) error {
+	switch sc.Type() {
+	case NoCommandType:
+		return nil
+	default:
+		return fmt.Errorf("'next-image' takes no sub commands. got: '%s'", sc.Type())
+	}
+}
+
+func (cmd *NextImageCommand) Execute() error {
+	url := fmt.Sprintf("http://127.0.0.1%s/next-image", TbgPort)
+	resp, err := http.Post(url, "application/json", nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}

--- a/command_quit.go
+++ b/command_quit.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type QuitCommand struct{}
+
+func (cmd *QuitCommand) Type() CommandType { return QuitCommandType }
+
+func (r *QuitCommand) Debug() {
+	fmt.Println("Quit Command Command:", r.Type())
+}
+
+func (cmd *QuitCommand) ValidateValue(val *string) error {
+	if val == nil || *val == "" {
+		return nil
+	}
+	return fmt.Errorf("'quit' takes no args. got: '%s'", *val)
+}
+
+func (cmd *QuitCommand) ValidateFlag(f Flag) error {
+	return fmt.Errorf("'quit' takes no flags. got: '%s'", f.Type)
+}
+
+func (cmd *QuitCommand) ValidateSubCommand(sc Command) error {
+	switch sc.Type() {
+	case NoCommandType:
+		return nil
+	default:
+		return fmt.Errorf("'quit' takes no sub commands. got: '%s'", sc.Type())
+	}
+}
+
+func (cmd *QuitCommand) Execute() error {
+	url := fmt.Sprintf("http://127.0.0.1%s/quit", TbgPort)
+	resp, err := http.Post(url, "application/json", nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	fmt.Println("resp:", resp.Status)
+	return nil
+}

--- a/docs/server_commands_usage.md
+++ b/docs/server_commands_usage.md
@@ -1,0 +1,76 @@
+# Table of Contents
+- [Server Commands](#server-commands)
+  - [Commands](#commands)
+- [Keybind Examples](#keybind-examples)
+---
+
+# Server Commands
+```zsh
+tbg <server-command>
+```
+These commands only work when there's a **tbg** server active. See [run](https://github.com/saltkid/tbg/blob/main/docs/run_command_usage.md)
+to learn more about starting a **tbg** server. Usage is the same as other
+commands.
+
+## Commands
+All available APIs have an associated command. If there is no command for an
+action, there is no API for it.
+1. next-image
+    - triggers an image change in the currently running **tbg** server
+    - if no server is found, this will fail
+    - curl equivalent: `curl -X POST localhost:9545/next-image`
+2. quit
+    - stops the currently running **tbg** server
+    - if no server is found, this will fail
+    - curl equivalent: `curl -X POST localhost:9545/quit`
+
+These are useful when integrating it with the shell through keybinds.
+# Keybind Examples
+1. powershell
+
+In your `$PROFILE`, do:
+```powershell
+# Auto start tbg server at every new pwsh instance.
+# Since tbg uses one port, starting another server through `tbg run`
+# will fail quietly in the background.
+Start-Job -Name tbg-server -ScriptBlock { tbg.exe run -p pwsh } | Out-Null
+
+# change image through ctrl+i
+Set-PSReadLineKeyHandler -Key "Ctrl+i" -ScriptBlock {
+  tbg.exe next-image &
+  # or the curl equivalent: curl -X POST localhost:9545/next-image &
+}
+
+# quit server through Ctrl+Alt+i
+Set-PSReadLineKeyHandler -Key "Ctrl+Alt+i" -ScriptBlock {
+  tbg.exe quit &
+  # or the curl equivalent: curl -X POST localhost:9545/quit &
+}
+```
+2. zsh (in wsl)
+
+Assuming the wsl distro is Debian, in your `.zshrc`, do:
+```zsh
+# Auto start tbg server at every new wsl Debian instance.
+# Reference the exe built for windows since windows have the proper environment
+# variables needed to edit wt's settings.json
+tbg.exe run -p Debian &>/dev/null &!
+
+# register functions as zle widget
+function __tbg_next_image() {
+  tbg.exe next-image &>/dev/null &!
+  # or the curl equivalent: curl -X POST localhost:9545/next-image &>/dev/null &!
+}
+function __tbg_quit() {
+  tbg.exe quit &>/dev/null &!
+  # or the curl equivalent: curl -X POST localhost:9545/quit &>/dev/null &!
+}
+zle -N __tbg_next_image
+zle -N __tbg_quit
+
+# change image through ctrl+i
+bindkey '^I' __tbg_next_image
+
+# quit server through Ctrl+Alt+i
+bindkey '^[^I' __tbg_quit
+```

--- a/main.go
+++ b/main.go
@@ -11,14 +11,11 @@ func main() {
 		fmt.Println(err)
 		return
 	}
-	// LogTokens(tokens)
 	command, err := ParseArgs(tokens)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
-	// command.Debug()
-	ClearScreen()
 	err = command.Execute()
 	if err != nil {
 		fmt.Println(err)

--- a/style.go
+++ b/style.go
@@ -54,10 +54,6 @@ func (s *Styled) Italic() *Styled {
 	return s.Format(Italic)
 }
 
-func ClearScreen() {
-	fmt.Println("\033[H\033[2J")
-}
-
 func IsImageFile(f string) bool {
 	f = strings.ToLower(filepath.Ext(f))
 	return f == ".png" ||

--- a/tbg.go
+++ b/tbg.go
@@ -86,9 +86,6 @@ func (tbg *TbgState) Start() error {
 	if err := tbg.updateCurrentPathState(); err != nil {
 		return fmt.Errorf("Failed to initialize tbg: %s", err.Error())
 	}
-	if err := tbg.changeImage(); err != nil {
-		return err
-	}
 	go tbg.readUserInput()
 	go tbg.imageUpdateTicker()
 	go tbg.startServer()

--- a/tbg.go
+++ b/tbg.go
@@ -186,10 +186,12 @@ func (tbg *TbgState) imageUpdateTicker() {
 
 // may emit TbgState.Events.Error (e.g. port is taken)
 func (tbg *TbgState) startServer() {
-	http.HandleFunc("POST /next-image", func(_ http.ResponseWriter, _ *http.Request) {
+	http.HandleFunc("POST /next-image", func(w http.ResponseWriter, _ *http.Request) {
 		tbg.Events.NextImage <- struct{}{}
+		fmt.Fprint(w, "next-image: changed image successfully")
 	})
 	http.HandleFunc("POST /quit", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "quit: stopped server successfully. Goodbye!")
 		close(tbg.Events.Done)
 	})
 	err := http.ListenAndServe(TbgPort, nil)


### PR DESCRIPTION
## New
1. `tbg run` now starts an http server that exposes POST endpoints to trigger tbg actions
    - port is `:9545`
    - currently the actions are: `next-image` to change the background image, and `quit` to stop the server
    - all actions have an exposed POST API.
2. new server commands as convenience wrappers around something like `curl` to make a request to **tbg's** POST endpoints
    - example: `tbg next-image` is equivalent to `curl -X POST localhost:9545/next-image`
3. in server command docs, there are example keybind setups for powershell and zsh

## Changes
- tbg commands no longer clear the screen