### PR TITLE
Feat/port config field

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,13 @@ go to the documentation of the command instead.
 1. `-a, --alignment`
 2. `-i, --interval`
 3. `-o, --opacity`
-4. `-p, --profile`
-5. `-s, --stretch`
+4. `-P, --port`
+5. `-p, --profile`
+6. `-s, --stretch`
 
 ---
 # Credits
 - [Windows Terminal](https://github.com/microsoft/terminal)
 - [keyboard](https://github.com/eiannone/keyboard) for handling key events
+- [levenshtein](github.com/agnivade/levenshtein) for suggesting similar profile names
 - [saltkid](https://github.com/saltkid)

--- a/command_config.go
+++ b/command_config.go
@@ -80,7 +80,7 @@ func (cmd *ConfigCommand) Execute() error {
 	if err != nil {
 		return err
 	}
-	isEditingConfig := cmd.Profile != nil || cmd.Interval != nil
+	isEditingConfig := cmd.Profile != nil || cmd.Interval != nil || cmd.Port != nil
 	if isEditingConfig {
 		config.EditConfig(configPath, cmd.Interval, cmd.Port, cmd.Profile)
 	} else {

--- a/command_config.go
+++ b/command_config.go
@@ -6,8 +6,9 @@ import (
 )
 
 type ConfigCommand struct {
-	Profile  *string
 	Interval *uint16
+	Port     *uint16
+	Profile  *string
 }
 
 func (cmd *ConfigCommand) Type() CommandType { return ConfigCommandType }
@@ -38,6 +39,12 @@ func (cmd *ConfigCommand) ValidateFlag(f Flag) error {
 			return err
 		}
 		cmd.Interval = val
+	case PortFlag:
+		val, err := ValidatePort(f.Value)
+		if err != nil {
+			return err
+		}
+		cmd.Port = val
 	case ProfileFlag:
 		val, err := ValidateProfile(f.Value)
 		if err != nil {
@@ -75,7 +82,7 @@ func (cmd *ConfigCommand) Execute() error {
 	}
 	isEditingConfig := cmd.Profile != nil || cmd.Interval != nil
 	if isEditingConfig {
-		config.EditConfig(configPath, cmd.Profile, cmd.Interval)
+		config.EditConfig(configPath, cmd.Interval, cmd.Port, cmd.Profile)
 	} else {
 		config.Log(configPath)
 	}

--- a/command_help.go
+++ b/command_help.go
@@ -156,7 +156,10 @@ func RunHelp(verbose bool) {
   4. -p, --profile   [arg]
          [default, n]
          where n is the list index Windows Terminal uses to identify the profile (starting from 1)
-  5. -i, --interval  [arg]
+  5. -P, --port   [arg]
+         [any positive integer]
+         port to be used by tbg server to listen to POST requests
+  6. -i, --interval  [arg]
          [any positive integer]
          note that this is in minutes
 
@@ -165,10 +168,7 @@ func RunHelp(verbose bool) {
   Press a key to execute the command
   1. q: [q]uit tbg
   2. n: goes to [n]ext image
-  3. p: goes to [p]revious image
-  4. f: goes [f]orward to next image collection dir
-  5. b: goes [b]ack to previous image collection dir
-  6. c: list all [c]ommands
+  3. c: list all [c]ommands
 
   `, Decorate("Examples").Bold(), `:
   1. tbg run
@@ -182,6 +182,7 @@ func RunHelp(verbose bool) {
       |   - path: /path/to/images/dir2 |   - path: /path/to/images/dir2
       |                                |
       | profile: default               | profile: 2
+      | port: 9545                     | port: 9545
       | interval: 30                   | interval: 5
       --------------------------       --------------------------------
      This means that instead of editing the default profile, it will edit the
@@ -348,7 +349,10 @@ func ConfigHelp(verbose bool) {
   1. -p, --profile   [arg]
          [default, n]
          where n is the list index Windows Terminal uses to identify the profile (starting from 1)
-  2. -i, --interval  [arg]
+  2. -P, --port   [arg]
+         [any positive integer]
+         port to be used by tbg server to listen to POST requests
+  3. -i, --interval  [arg]
          [any positive integer]
          note that this is in minutes.
 
@@ -360,6 +364,7 @@ func ConfigHelp(verbose bool) {
       |   - path: /path/to/images/dir
       |
       | profile: default
+      | port: 9545
       | interval: 30
       |
       --------------------------
@@ -370,7 +375,7 @@ func ConfigHelp(verbose bool) {
       | paths:                         | paths:
       |   - path: /path/to/images/dir1 |   - path: /path/to/images/dir1
       |                                |
-      | profile: right                 | profile: 1
+      | profile: default               | profile: 1
       |                                |
       | other fields...                | other fields...
       --------------------------       --------------------------------

--- a/command_next_image.go
+++ b/command_next_image.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"os"
 )
 
 type NextImageCommand struct{}
@@ -34,11 +35,24 @@ func (cmd *NextImageCommand) ValidateSubCommand(sc Command) error {
 }
 
 func (cmd *NextImageCommand) Execute() error {
-	url := fmt.Sprintf("http://127.0.0.1%s/next-image", TbgPort)
+	configPath, err := ConfigPath()
+	if err != nil {
+		return err
+	}
+	yamlFile, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("Failed to read config file %s: %s", configPath, err)
+	}
+	config := new(Config)
+	err = config.Unmarshal(yamlFile)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d/next-image", config.Port)
 	resp, err := http.Post(url, "application/json", nil)
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	resp.Body.Close()
 	return nil
 }

--- a/command_quit.go
+++ b/command_quit.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"os"
 )
 
 type QuitCommand struct{}
@@ -34,7 +35,20 @@ func (cmd *QuitCommand) ValidateSubCommand(sc Command) error {
 }
 
 func (cmd *QuitCommand) Execute() error {
-	url := fmt.Sprintf("http://127.0.0.1%s/quit", TbgPort)
+	configPath, err := ConfigPath()
+	if err != nil {
+		return err
+	}
+	yamlFile, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("Failed to read config file %s: %s", configPath, err)
+	}
+	config := new(Config)
+	err = config.Unmarshal(yamlFile)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d/quit", config.Port)
 	resp, err := http.Post(url, "application/json", nil)
 	if err != nil {
 		return err

--- a/config.go
+++ b/config.go
@@ -11,14 +11,18 @@ import (
 
 const (
 	DefaultAlignment string  = "center"
+	DefaultInterval  uint16  = 30
 	DefaultOpacity   float32 = 1.0
+	DefaultPort      uint16  = 9545
+	DefaultProfile   string  = "default"
 	DefaultStretch   string  = "uniformToFill"
 )
 
 type Config struct {
-	Paths    []ImagesPath `yaml:"paths"`
 	Interval uint16       `yaml:"interval"`
+	Port     uint16       `yaml:"port"`
 	Profile  string       `yaml:"profile"`
+	Paths    []ImagesPath `yaml:"paths"`
 }
 
 func (cfg *Config) String() string {
@@ -31,6 +35,7 @@ func (cfg *Config) String() string {
 		return ret
 	}(), `
     Interval: `, cfg.Interval, `
+    Port: `, cfg.Port, `
     Profile: `, cfg.Profile,
 	)
 }
@@ -195,18 +200,23 @@ func (cfg *Config) RemovePath(
 
 func (cfg *Config) EditConfig(
 	configPath string,
-	profile *string,
 	interval *uint16,
+	port *uint16,
+	profile *string,
 ) error {
 	// key:val = old:new
 	edited := make(map[string]string, 0)
-	if profile != nil {
-		edited[cfg.Profile] = *profile
-		cfg.Profile = *profile
-	}
 	if interval != nil {
 		edited[strconv.Itoa(int(cfg.Interval))] = strconv.Itoa(int(*interval))
 		cfg.Interval = *interval
+	}
+	if port != nil {
+		edited[strconv.Itoa(int(cfg.Port))] = strconv.Itoa(int(*port))
+		cfg.Port = *port
+	}
+	if profile != nil {
+		edited[cfg.Profile] = *profile
+		cfg.Profile = *profile
 	}
 	template := NewConfigTemplate(configPath)
 	template.YamlContents, _ = yaml.Marshal(cfg)
@@ -278,6 +288,7 @@ func (cfg *Config) Log(configPath string) ConfigLogger {
 		}
 	}
 	fmt.Printf("|\n%-25s%s\n", "| profile:", cfg.Profile)
+	fmt.Printf("|\n%-25s%d\n", "| port:", cfg.Port)
 	fmt.Printf("%-25s%d\n", "| interval:", cfg.Interval)
 	fmt.Println("------------------------------------------------------------------------------------")
 	return ConfigLogger{}

--- a/config_template.go
+++ b/config_template.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 )
 
 type ConfigTemplate struct {
@@ -47,12 +48,13 @@ paths:
 #------------------------------------------
 `),
 		YamlContents: []byte(paths + `
-profile: default
-interval: 30
+port:` + strconv.FormatUint(uint64(DefaultPort), 10) + `
+profile:` + DefaultProfile + `
+interval:` + strconv.FormatUint(uint64(DefaultInterval), 10) + `
 
-alignment: center
-stretch: uniformToFill
-opacity: 1.0
+alignment: ` + DefaultAlignment + `
+stretch: ` + DefaultStretch + `
+opacity: ` + strconv.FormatFloat(float64(DefaultOpacity), 'f', -1, 32) + `
 `),
 		EndDesc: []byte(`
 #------------------------------------------
@@ -70,6 +72,8 @@ opacity: 1.0
 #       stretch:   (optional) image stretch in Windows Terminal
 #                  valid values: fill, none, uniform, uniformToFill
 #                  https://learn.microsoft.com/en-us/windows/terminal/customize-settings/profile-appearance#background-image-stretch-mode 
+#
+#   port: port used by tbg server to send POST requests to, to trigger tbg actions such as change image and quit server
 #
 #   profile: profile profile in Windows Terminal
 #      valid values: default, 0, 1, ..., n

--- a/docs/add_command_usage.md
+++ b/docs/add_command_usage.md
@@ -32,6 +32,7 @@ paths: []
 
 interval: 30
 profile: default
+port: 9545
 ```
 If we run:
 ```bash
@@ -45,6 +46,7 @@ paths:
 
 interval: 30
 profile: default
+port: 9545
 ```
 ### Adding a path with options
 Let's continue with our config and run this:
@@ -62,6 +64,7 @@ paths:
 
 interval: 30
 profile: default
+port: 9545
 ```
 Let's add another one:
 ```bash
@@ -76,10 +79,6 @@ paths:
   opacity: 0.5
 - path: path/to/images/dir3
   alignment: right
-
-alignment: center
-stretch: uniform
-opacity: 0.5
 ```
 Options that were not specified will inherit their respective default value
 (`stretch` and `opacity` will be `center` and `1.0` in this example)
@@ -100,6 +99,7 @@ paths:
 
 interval: 30
 profile: default
+port: 9545
 ```
 Let's fill assign the opacity too
 ```bash
@@ -115,6 +115,7 @@ paths:
 
 interval: 30
 profile: default
+port: 9545
 ```
 #### Changing an option of an existing path
 Let's change the opacity and stretch:
@@ -133,6 +134,7 @@ paths:
 
 interval: 30
 profile: default
+port: 9545
 ```
 Let's change the alignment too
 ```bash
@@ -148,4 +150,5 @@ paths:
 
 interval: 30
 profile: default
+port: 9545
 ```

--- a/docs/config_command_usage.md
+++ b/docs/config_command_usage.md
@@ -40,6 +40,7 @@ Output on console should look something like this
 |   opacity: 0.250000
 |
 | profile:               default
+| port:                  9545
 | interval:              30
 ------------------------------------------------------------------------------------
 ```
@@ -60,6 +61,7 @@ tbg config --profile pwsh
 |   opacity: 0.250000
 |
 | profile:               pwsh # used to be default
+| port:                  9545
 | interval:              30
 ------------------------------------------------------------------------------------
 ```
@@ -78,6 +80,7 @@ tbg config --interval 5
 |   opacity: 0.250000
 |
 | profile:               1        
+| port:                  9545
 | interval:              5 # used to be 30
 ------------------------------------------------------------------------------------
 ```

--- a/docs/remove_command_usage.md
+++ b/docs/remove_command_usage.md
@@ -31,6 +31,7 @@ paths:
 
 interval: 30
 profile: default
+port: 9545
 ```
 If we run:
 ```bash
@@ -43,6 +44,7 @@ paths: []
 
 interval: 30
 profile: default
+port: 9545
 ```
 ### Removing options from a path
 Let's use this config
@@ -55,6 +57,7 @@ paths:
 
 interval: 30
 profile: default
+port: 9545
 ```
 Let's "remove" the alignment flag of `path/to/images/dir1`:
 ```bash
@@ -68,6 +71,7 @@ paths:
 
 interval: 30
 profile: default
+port: 9545
 ```
 The path will now inherit the default `alignment` value (`center`).
 Let's remove stretch next.
@@ -82,6 +86,7 @@ paths:
 
 interval: 30
 profile: default
+port: 9545
 ```
 The path will now inherit the default `stretch` value (`uniformToFill`).
 
@@ -95,6 +100,7 @@ paths:
 
 interval: 30
 profile: default
+port: 9545
 ```
 Now all the path will inehrit the default alignment (`center`), stretch
 (`uniformToFill`), and opacity (`1.0`).

--- a/docs/run_command_usage.md
+++ b/docs/run_command_usage.md
@@ -4,7 +4,7 @@
 - [Executing with flags](#executing-with-flags)
 - [Usage](#usage)
     - [Normal Execution, key events, and path specific options](#normal-execution)
-    - [Overriding `profile` and `interval` fields](#overriding-profile-and-interval-fields)
+    - [Overriding `profile`, `port`, and `interval` fields](#overriding-profile-port-and-interval-fields)
     - [Overriding default values](#overriding-default-values)
 ---
 
@@ -28,7 +28,7 @@ only be one `.tbg.yml`**. For more information, see documentation on
 - `n`: goes to next image
 
 # Executing with flags
-#### Valid Flags: `--profile`, `--interval`, `--alignment`, `--opacity`, `--stretch`
+#### Valid Flags: `--profile`, `--interval`, `--port`, `--alignment`, `--opacity`, `--stretch`
 
 The flags specified will override any per path options specified. So if there is
 a `path/to/dir` with the alignment `center`, **tbg** will use whatever value
@@ -59,6 +59,7 @@ paths:
   opacity: 0.35
 
 profile: default
+port: 9545
 interval: 30
 ```
 This just means that when we do `tbg run`, we want to change the background
@@ -68,24 +69,27 @@ image is chosen randomly from images under `/path/to/dir1` and `/path/to/dir2`.
 Now let's quit **tbg** by pressing `q` or `ctrl+c`.
 
 ---
-### Overriding `profile` and `interval` fields
+### Overriding `profile`, `port`, and `interval` fields
 
 Instead of `tbg run`, let's do:
 ```bash
-tbg run --profile 1 --interval 5
+tbg run --profile 1 --interval 5 --port 8000
 ```
 ```yml
 paths:
 - path: path/to/dir1
 
 profile: default
+port: 9545
 interval: 30
 ```
 
-The `--profile` and `--interval` flags will override the values in the config.
-Again, not edit them. This means instead of changing the background image of
-the `default` profile every 30 minutes, it will change the background image of
-the first profile under `list` field in `settings.json` every 5 minutes instead
+The `--profile`, `--port`, and `--interval` flags will override the values in
+the config. Again, not edit them. This means instead of changing the background
+image of the `default` profile every 30 minutes, it will change the background
+image of the first profile under `list` field in `settings.json` every 5
+minutes instead. The server will run in port 8000 instead of what is defined
+in the config (9545)
 
 ---
 ### Overriding default values
@@ -102,6 +106,7 @@ paths:
   opacity: 0.25
 
 profile: default
+port: 9545
 interval: 30
 ```
 Let's do:

--- a/docs/server_commands_usage.md
+++ b/docs/server_commands_usage.md
@@ -31,20 +31,18 @@ These are useful when integrating it with the shell through keybinds.
 In your `$PROFILE`, do:
 ```powershell
 # Auto start tbg server at every new pwsh instance.
-# Since tbg uses one port, starting another server through `tbg run`
-# will fail quietly in the background.
+# Since tbg uses the one port defined in the config, starting another server
+# through `tbg run` will fail quietly in the background.
 Start-Job -Name tbg-server -ScriptBlock { tbg.exe run -p pwsh } | Out-Null
 
 # change image through ctrl+i
 Set-PSReadLineKeyHandler -Key "Ctrl+i" -ScriptBlock {
   tbg.exe next-image &
-  # or the curl equivalent: curl -X POST localhost:9545/next-image &
 }
 
 # quit server through Ctrl+Alt+i
 Set-PSReadLineKeyHandler -Key "Ctrl+Alt+i" -ScriptBlock {
   tbg.exe quit &
-  # or the curl equivalent: curl -X POST localhost:9545/quit &
 }
 ```
 2. zsh (in wsl)
@@ -59,11 +57,9 @@ tbg.exe run -p Debian &>/dev/null &!
 # register functions as zle widget
 function __tbg_next_image() {
   tbg.exe next-image &>/dev/null &!
-  # or the curl equivalent: curl -X POST localhost:9545/next-image &>/dev/null &!
 }
 function __tbg_quit() {
   tbg.exe quit &>/dev/null &!
-  # or the curl equivalent: curl -X POST localhost:9545/quit &>/dev/null &!
 }
 zle -N __tbg_next_image
 zle -N __tbg_quit

--- a/docs/tbg.yml.md
+++ b/docs/tbg.yml.md
@@ -20,6 +20,7 @@ paths:
   # opacity: 0.25    # override default opacity of 1.0
 
 profile: default
+port: 9545
 interval: 30
 
 #------------------------------------------
@@ -62,7 +63,10 @@ Although you can edit the fields in the config directly, it is recommended to us
 2. **interval**
     - *args*: any positive integer 
     - time in minutes between each image change.
-3. **paths** 
+3. **port**
+    - *args*: any positive integer
+    - port that the tbg server uses to listen to POST requests
+4. **paths** 
     - *args*:
         - `[]`
         - `- path: path/to/dir1` 

--- a/flag.go
+++ b/flag.go
@@ -11,6 +11,7 @@ const (
 	AlignmentFlag
 	IntervalFlag
 	OpacityFlag
+	PortFlag
 	ProfileFlag
 	StretchFlag
 )
@@ -25,6 +26,8 @@ func (f FlagType) String() string {
 		return "none"
 	case OpacityFlag:
 		return "--opacity"
+	case PortFlag:
+		return "--port"
 	case ProfileFlag:
 		return "--profile"
 	case StretchFlag:
@@ -47,6 +50,8 @@ func ToFlag(s string) (*Flag, error) {
 		return &Flag{Type: IntervalFlag}, nil
 	case "--opacity", "-o":
 		return &Flag{Type: OpacityFlag}, nil
+	case "--port", "-P":
+		return &Flag{Type: PortFlag}, nil
 	case "--profile", "-p":
 		return &Flag{Type: ProfileFlag}, nil
 	case "--stretch", "-s":

--- a/flag_validators.go
+++ b/flag_validators.go
@@ -47,6 +47,18 @@ func ValidateOpacity(val *string) (*float32, error) {
 	return &ret, nil
 }
 
+func ValidatePort(val *string) (*uint16, error) {
+	if val == nil {
+		return nil, fmt.Errorf("--port must have an argument. got none")
+	}
+	valNum, err := strconv.Atoi(*val)
+	if err == nil && valNum < 1 {
+		return nil, fmt.Errorf("invalid arg '%d' for --port: must be positive.", valNum)
+	}
+	ret := uint16(valNum)
+	return &ret, nil
+}
+
 func ValidateProfile(val *string) (*string, error) {
 	if val == nil {
 		return nil, fmt.Errorf("--profile must have an argument. got none")

--- a/flag_validators.go
+++ b/flag_validators.go
@@ -52,7 +52,10 @@ func ValidatePort(val *string) (*uint16, error) {
 		return nil, fmt.Errorf("--port must have an argument. got none")
 	}
 	valNum, err := strconv.Atoi(*val)
-	if err == nil && valNum < 1 {
+	if err != nil {
+		return nil, fmt.Errorf("invalid arg '%s' for --port: %s", *val, err)
+	}
+	if valNum < 1 {
 		return nil, fmt.Errorf("invalid arg '%d' for --port: must be positive.", valNum)
 	}
 	ret := uint16(valNum)

--- a/style.go
+++ b/style.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 )

--- a/tbg.go
+++ b/tbg.go
@@ -2,14 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/eiannone/keyboard"
 	"math/rand/v2"
 	"net/http"
+	"strconv"
 	"time"
-)
 
-const (
-	TbgPort = ":9545"
+	"github.com/eiannone/keyboard"
 )
 
 type TbgState struct {
@@ -194,7 +192,8 @@ func (tbg *TbgState) startServer() {
 		fmt.Fprint(w, "quit: stopped server successfully. Goodbye!")
 		close(tbg.Events.Done)
 	})
-	err := http.ListenAndServe(TbgPort, nil)
+	tbgPort := ":" + strconv.FormatUint(uint64(tbg.Config.Port), 10)
+	err := http.ListenAndServe(tbgPort, nil)
 	if err != nil {
 		tbg.Events.Error <- err
 	}


### PR DESCRIPTION
closes #37 

---

## New
1. `port` field in config for specifying which port tbg server uses to listen to POST requests
    - added `--port` flag for both `config` for editing config and `run` for overriding defined `port` value

## Changes
- read `port` value in config to use in: 
  - starting tbg server
  - making POST requests through `next-image` and `quit` server commands
- updated docs to include new `port` field and `--port` flag for `config` and `run` commands