### PR TITLE
Feat/set image endpoint and command

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,12 +146,12 @@ These commands only work when there's a **tbg** server active. Usage is the
 same as other commands.
 1. next-image
     - triggers an image change
-    - curl equivalent: `curl -X POST localhost:9545/next-image`
-2. quit
+2. set-image
+    - sets a specified image as the background image
+3. quit
     - stops the server
-    - curl equivalent: `curl -X POST localhost:9545/quit`
 
-*Tip: you can assign these commands to keybinds in Windows Terminal Settings*
+*Tip: you can assign these commands to keybinds*
 
 ## Flags
 Flags behave differently based on the command so for more detailed explanation,

--- a/command.go
+++ b/command.go
@@ -33,6 +33,8 @@ func ToCommand(s string) (Command, error) {
 		return new(VersionCommand), nil
 	case "next-image":
 		return new(NextImageCommand), nil
+	case "set-image":
+		return new(SetImageCommand), nil
 	case "quit":
 		return new(QuitCommand), nil
 	default:
@@ -51,6 +53,7 @@ const (
 	HelpCommandType
 	VersionCommandType
 	NextImageCommandType
+	SetImageCommandType
 	QuitCommandType
 )
 
@@ -72,6 +75,8 @@ func (c CommandType) String() string {
 		return "version"
 	case NextImageCommandType:
 		return "next-image"
+	case SetImageCommandType:
+		return "set-image"
 	case QuitCommandType:
 		return "quit"
 	default:
@@ -99,6 +104,8 @@ func (c CommandType) ToCommand() Command {
 		return new(VersionCommand)
 	case NextImageCommandType:
 		return new(NextImageCommand)
+	case SetImageCommandType:
+		return new(SetImageCommand)
 	case QuitCommandType:
 		return new(QuitCommand)
 	default: // case: NoCommandType

--- a/command_help.go
+++ b/command_help.go
@@ -73,6 +73,7 @@ func (cmd *HelpCommand) Execute() error {
 		)
 		RunHelp(false)
 		NextImageHelp(false)
+		SetImageHelp(false)
 		QuitHelp(false)
 		AddHelp(false)
 		RemoveHelp(false)
@@ -111,6 +112,8 @@ func (cmd *HelpCommand) Execute() error {
 			VersionHelp(true)
 		case NextImageCommandType:
 			NextImageHelp(true)
+		case SetImageCommandType:
+			SetImageHelp(true)
 		case QuitCommandType:
 			QuitHelp(true)
 		}
@@ -433,6 +436,23 @@ func NextImageHelp(verbose bool) {
 	if verbose {
 		fmt.Print(`
   `, Decorate("Args").Bold(), `: next-image does not take args
+
+  `, Decorate("Examples").Bold(), `:
+  1. tbg next-image
+`)
+	}
+}
+
+func SetImageHelp(verbose bool) {
+	fmt.Printf("%-33s%s",
+		Decorate("  set-image").Bold(),
+		"sets the specified image as the background image\n",
+	)
+	if verbose {
+		fmt.Print(`
+  `, Decorate("Args").Bold(), `:
+  1. path/to/image/file
+     Path to the image file you want to set as the background image
 
   `, Decorate("Examples").Bold(), `:
   1. tbg next-image

--- a/command_set_image.go
+++ b/command_set_image.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+type SetImageCommand struct {
+	Path      string
+	Alignment *string
+	Opacity   *float32
+	Stretch   *string
+}
+
+func (cmd *SetImageCommand) Type() CommandType { return SetImageCommandType }
+
+func (r *SetImageCommand) Debug() {
+	fmt.Println("Set Image Command:", r.Type())
+}
+
+func (cmd *SetImageCommand) ValidateValue(val *string) error {
+	if val == nil {
+		return fmt.Errorf("'set-image' must have an argument. got none")
+	}
+	absPath, err := filepath.Abs(*val)
+	if err != nil {
+		return fmt.Errorf("Failed to get absolute path of %s: %s", *val, err)
+	}
+	if _, err := os.Stat(absPath); os.IsNotExist(err) {
+		return fmt.Errorf("%s does not exist: %s", *val, err.Error())
+	}
+	if !IsImageFile(absPath) {
+		return fmt.Errorf("Not an image file: %s", *val)
+	}
+	cmd.Path = filepath.ToSlash(absPath)
+	return nil
+}
+
+func (cmd *SetImageCommand) ValidateFlag(f Flag) error {
+	switch f.Type {
+	case AlignmentFlag:
+		val, err := ValidateAlignment(f.Value)
+		if err != nil {
+			return err
+		}
+		cmd.Alignment = val
+	case OpacityFlag:
+		val, err := ValidateOpacity(f.Value)
+		if err != nil {
+			return err
+		}
+		cmd.Opacity = val
+	case StretchFlag:
+		val, err := ValidateStretch(f.Value)
+		if err != nil {
+			return err
+		}
+		cmd.Stretch = val
+	default:
+		return fmt.Errorf("invalid flag for 'next-image': '%s'", f.Type)
+	}
+	return nil
+}
+
+func (cmd *SetImageCommand) ValidateSubCommand(sc Command) error {
+	switch sc.Type() {
+	case NoCommandType:
+		return nil
+	default:
+		return fmt.Errorf("'next-image' takes no sub commands. got: '%s'", sc.Type())
+	}
+}
+
+type SetImageRequestBody struct {
+	Path      string   `json:"path"`
+	Alignment *string  `json:"alignment,omitempty"`
+	Opacity   *float32 `json:"opacity,omitempty"`
+	Stretch   *string  `json:"stretch,omitempty"`
+}
+
+func (cmd *SetImageCommand) Execute() error {
+	configPath, err := ConfigPath()
+	if err != nil {
+		return err
+	}
+	yamlFile, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("Failed to read config file %s: %s", configPath, err)
+	}
+	config := new(Config)
+	err = config.Unmarshal(yamlFile)
+	if err != nil {
+		return err
+	}
+	setImageArgs := SetImageRequestBody{
+		Path:      cmd.Path,
+		Alignment: cmd.Alignment,
+		Stretch:   cmd.Stretch,
+		Opacity:   cmd.Opacity,
+	}
+	reqBody, err := json.Marshal(setImageArgs)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request body: %s", err)
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d/set-image", config.Port)
+	resp, err := http.Post(url, "application/json", bytes.NewReader(reqBody))
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}

--- a/config.go
+++ b/config.go
@@ -374,8 +374,8 @@ func (log ConfigLogger) RunSettings(
 	profile string,
 	interval uint16,
 	alignment string,
-	stretch string,
 	opacity float32,
+	stretch string,
 ) ConfigLogger {
 	fmt.Println("| editing", profile, "profile")
 	fmt.Println("| image collection:", filepath.Dir(imagePath))

--- a/docs/server_commands_usage.md
+++ b/docs/server_commands_usage.md
@@ -17,10 +17,18 @@ All available APIs have an associated command. If there is no command for an
 action, there is no API for it.
 1. next-image
     - valid flags: `-a, --alignment`, `-o, --opacity`, `-s, --stretch`
-      - these will override the image properties of the next randomly chosen image
+      - these will override the image properties of the next randomly chosen
+      image
     - triggers an image change in the currently running **tbg** server
     - if no server is found, this will fail
-2. quit
+2. set-image
+    - arg: `/path/to/image/file`
+    - valid flags: `-a, --alignment`, `-o, --opacity`, `-s, --stretch`
+      - the default values for each will be used if not specified
+    - sets the specified image as the background image through an image change
+    in the currently runing **tbg** server
+    - if no server is found, this will fail
+3. quit
     - valid flags: none
     - stops the currently running **tbg** server
     - if no server is found, this will fail


### PR DESCRIPTION
closes #39 

---

## New
1. `set-image` API endpoint and server command to set a specified image as the background image
    - optional `--alignment`, `--opacity`, `--stretch` flags
    - default values of each will be used if not specified

## Changes
- setting image requires all properties to be present beforehand
  - that means separate out selecting random image and overriding properties with optional flags before setting the background image
- update docs and help messages to include `set-image`