### PR TITLE
docs/remove flag help messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
     - [Fields](#fields)
 - [Commands](#commands)
     - [Server Commands](#server-commands)
-    - [Flags](#flags)
 - [Credits](#credits)
 
 ---
@@ -119,52 +118,48 @@ For a more detailed explanation on each command, follow the command name links
     - edit `settings.json` used by *Windows Terminal* using settings from
     `.tbg.yml`. If any of the flags are specified, it will use those values in
     editing `settings.json` instead of what's specified in the `.tbg.yml`
-    - *args*: none 
+    - *arg*: none 
     - *flags*: `-p, --profile`, `-i, --interval`, `-a, --alignment`,
     `-o, --opacity`, `-s, --stretch`
 2. [config](https://github.com/saltkid/tbg/blob/main/docs/config_command_usage.md) 
     - If no flags are present, it will print out `.tbg.yml` to console. If any
     of the flags are present, it will edit the fields of the config based on
     the flags and values passed
-    - *args*: none 
-    - *flags*: `-p, --profile`, `-i, --interval`
+    - *arg*: none 
+    - *flags*: `-p, --profile`, `-P, --port`, `-i, --interval`
 3. [add](https://github.com/saltkid/tbg/blob/main/docs/add_command_usage.md) 
     - Add a path containing images to `.tbg.yml`.
     - If any flags are present, this will add those options to that path,
     regardless of whether the path exists or not
-    - *args*: `/path/to/dir` 
+    - *arg*: `/path/to/dir` 
     - *flags*: `-a, --alignment`, `-o, --opacity`, `-s, --stretch` 
 4. [remove](https://github.com/saltkid/tbg/blob/main/docs/remove_command_usage.md) 
     - Remove a path from `.tbg.yml`.
     - If any flags are present, it will remove only those options of that path
-    - *args*: `/path/to/dir` 
+    - *arg*: `/path/to/dir` 
     - *flags*: `-a, --alignment`, `-o, --opacity`, `-s, --stretch` 
 5. help
     - Prints the general help message when no arg is given
     - Prints the help message/s of command/s and/or flag/s if specified
-    - *args*: no arg, or any command or any flag (can be multiple)
+    - *arg*: no arg, or any command (can be multiple)
 
 ## [Server Commands](https://github.com/saltkid/tbg/blob/main/docs/server_commands_usage.md)
 These commands only work when there's a **tbg** server active. Usage is the
 same as other commands.
 1. next-image
     - triggers an image change
+    - *arg*: `/path/to/dir` 
+    - *flags*: `-a, --alignment`, `-o, --opacity`, `-s, --stretch`
 2. set-image
     - sets a specified image as the background image
+    - *arg*: `/path/to/image/file` 
+    - *flags*: `-a, --alignment`, `-o, --opacity`, `-s, --stretch`
 3. quit
     - stops the server
+    - *arg*: none
+    - *flags*: none
 
 *Tip: you can assign these commands to keybinds*
-
-## Flags
-Flags behave differently based on the command so for more detailed explanation,
-go to the documentation of the command instead.
-1. `-a, --alignment`
-2. `-i, --interval`
-3. `-o, --opacity`
-4. `-P, --port`
-5. `-p, --profile`
-6. `-s, --stretch`
 
 ---
 # Credits

--- a/command.go
+++ b/command.go
@@ -7,9 +7,6 @@ import (
 type Command interface {
 	// returns the command type of the command struct
 	Type() CommandType
-	// prints out debug information
-	Debug()
-	//
 	ValidateValue(val *string) error
 	ValidateFlag(f Flag) error
 	ValidateSubCommand(cmd Command) error

--- a/command_add.go
+++ b/command_add.go
@@ -15,7 +15,7 @@ type AddCommand struct {
 
 func (cmd *AddCommand) Type() CommandType { return AddCommandType }
 
-func (r *AddCommand) Debug() {
+func (r *AddCommand) String() {
 	fmt.Println("Add Command:", r.Type())
 	fmt.Println("Path:", r.Path)
 	fmt.Println("Flags:")

--- a/command_config.go
+++ b/command_config.go
@@ -13,7 +13,7 @@ type ConfigCommand struct {
 
 func (cmd *ConfigCommand) Type() CommandType { return ConfigCommandType }
 
-func (cmd *ConfigCommand) Debug() {
+func (cmd *ConfigCommand) String() {
 	fmt.Println("Config Command:", cmd.Type())
 	fmt.Println("Flags:")
 	if cmd.Profile != nil {

--- a/command_next_image.go
+++ b/command_next_image.go
@@ -16,7 +16,7 @@ type NextImageCommand struct {
 
 func (cmd *NextImageCommand) Type() CommandType { return NextImageCommandType }
 
-func (r *NextImageCommand) Debug() {
+func (r *NextImageCommand) String() {
 	fmt.Println("Next Image Command:", r.Type())
 }
 

--- a/command_quit.go
+++ b/command_quit.go
@@ -10,7 +10,7 @@ type QuitCommand struct{}
 
 func (cmd *QuitCommand) Type() CommandType { return QuitCommandType }
 
-func (r *QuitCommand) Debug() {
+func (r *QuitCommand) String() {
 	fmt.Println("Quit Command Command:", r.Type())
 }
 

--- a/command_remove.go
+++ b/command_remove.go
@@ -15,7 +15,7 @@ type RemoveCommand struct {
 
 func (cmd *RemoveCommand) Type() CommandType { return RemoveCommandType }
 
-func (cmd *RemoveCommand) Debug() {
+func (cmd *RemoveCommand) String() {
 	fmt.Println("Remove Command")
 	fmt.Println("Flags:")
 	if cmd.Alignment {

--- a/command_run.go
+++ b/command_run.go
@@ -15,7 +15,7 @@ type RunCommand struct {
 
 func (cmd *RunCommand) Type() CommandType { return RunCommandType }
 
-func (cmd *RunCommand) Debug() {
+func (cmd *RunCommand) String() {
 	fmt.Println("Run Command")
 	fmt.Println("Flags:")
 	if cmd.Alignment != nil {

--- a/command_set_image.go
+++ b/command_set_image.go
@@ -18,7 +18,7 @@ type SetImageCommand struct {
 
 func (cmd *SetImageCommand) Type() CommandType { return SetImageCommandType }
 
-func (r *SetImageCommand) Debug() {
+func (r *SetImageCommand) String() {
 	fmt.Println("Set Image Command:", r.Type())
 }
 

--- a/command_version.go
+++ b/command_version.go
@@ -9,7 +9,7 @@ var TbgVersion = "dev"
 type VersionCommand struct{}
 
 func (cmd *VersionCommand) Type() CommandType { return VersionCommandType }
-func (cmd *VersionCommand) Debug() {
+func (cmd *VersionCommand) String() {
 	fmt.Println("Version Command")
 	fmt.Println("version:", TbgVersion)
 }


### PR DESCRIPTION
closes #40 

---

Flag info is now in each command. This is for when commands have different uses for a flag.