### PR TITLE
Refactor/remove interactive keystrokes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 - [Installation](#installation)
     - [Building from source](#building-from-source)
 - [Usage](#usage)
-    - [Interactive Commands](#interactive-commands)
+    - [Automatically change background image at a set interval](#automatically-change-background-image-at-a-set-interval)
+    - [tbg server](#tbg-server)
 - [Config](#config)
     - [Fields](#fields)
 - [Commands](#commands)
@@ -67,17 +68,10 @@ On initial execution of `tbg run`, it will create a [default config](#config)
 manually **or** use [tbg commands](#commands) to edit these with input
 validation
 
-### tbg server
+## tbg server
 `tbg run` starts the **tbg** http server where POST requests can be made to
 trigger certain actions. These post requests can be made through [tbg server
 commands](#server-commands) for convenience
-
-## Interactive Commands
-While **tbg** is running, it takes in optional user input through key presses.
-- `q`: quit
-- `c`: shows the available commands
-- `n`: goes to the next image (randomly chosen)
-
 
 # Config
 **tbg** uses `.tbg.yml` to edit the `settings.json` *Windows Terminal* uses.
@@ -164,6 +158,5 @@ same as other commands.
 ---
 # Credits
 - [Windows Terminal](https://github.com/microsoft/terminal)
-- [keyboard](https://github.com/eiannone/keyboard) for handling key events
 - [levenshtein](github.com/agnivade/levenshtein) for suggesting similar profile names
 - [saltkid](https://github.com/saltkid)

--- a/command_next_image.go
+++ b/command_next_image.go
@@ -12,6 +12,7 @@ type NextImageCommand struct {
 	Alignment *string
 	Opacity   *float32
 	Stretch   *string
+	Port      *uint16
 }
 
 func (cmd *NextImageCommand) Type() CommandType { return NextImageCommandType }
@@ -41,6 +42,12 @@ func (cmd *NextImageCommand) ValidateFlag(f Flag) error {
 			return err
 		}
 		cmd.Opacity = val
+	case PortFlag:
+		val, err := ValidatePort(f.Value)
+		if err != nil {
+			return err
+		}
+		cmd.Port = val
 	case StretchFlag:
 		val, err := ValidateStretch(f.Value)
 		if err != nil {
@@ -91,7 +98,7 @@ func (cmd *NextImageCommand) Execute() error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal request body: %s", err)
 	}
-	url := fmt.Sprintf("http://127.0.0.1:%d/next-image", config.Port)
+	url := fmt.Sprintf("http://127.0.0.1:%d/next-image", Option(cmd.Port).UnwrapOr(config.Port))
 	resp, err := http.Post(url, "application/json", bytes.NewReader(reqBody))
 	if err != nil {
 		return err

--- a/command_run.go
+++ b/command_run.go
@@ -11,6 +11,7 @@ type RunCommand struct {
 	Alignment *string
 	Stretch   *string
 	Opacity   *float32
+	Port      *uint16
 }
 
 func (cmd *RunCommand) Type() CommandType { return RunCommandType }
@@ -26,6 +27,9 @@ func (cmd *RunCommand) String() {
 	}
 	if cmd.Opacity != nil {
 		fmt.Println(" ", OpacityFlag, *cmd.Opacity)
+	}
+	if cmd.Port != nil {
+		fmt.Println(" ", ProfileFlag, *cmd.Profile)
 	}
 	if cmd.Profile != nil {
 		fmt.Println(" ", ProfileFlag, *cmd.Profile)
@@ -62,6 +66,12 @@ func (cmd *RunCommand) ValidateFlag(f Flag) error {
 			return err
 		}
 		cmd.Opacity = val
+	case PortFlag:
+		val, err := ValidatePort(f.Value)
+		if err != nil {
+			return err
+		}
+		cmd.Port = val
 	case ProfileFlag:
 		val, err := ValidateProfile(f.Value)
 		if err != nil {
@@ -108,7 +118,7 @@ func (cmd *RunCommand) Execute() error {
 	if err != nil {
 		return err
 	}
-	return backgroundState.Start()
+	return backgroundState.Start(cmd.Port)
 }
 
 func (config *Config) determineExecutionFlags(cmd *RunCommand) (string, string, float32) {

--- a/command_set_image.go
+++ b/command_set_image.go
@@ -14,6 +14,7 @@ type SetImageCommand struct {
 	Alignment *string
 	Opacity   *float32
 	Stretch   *string
+	Port      *uint16
 }
 
 func (cmd *SetImageCommand) Type() CommandType { return SetImageCommandType }
@@ -54,6 +55,12 @@ func (cmd *SetImageCommand) ValidateFlag(f Flag) error {
 			return err
 		}
 		cmd.Opacity = val
+	case PortFlag:
+		val, err := ValidatePort(f.Value)
+		if err != nil {
+			return err
+		}
+		cmd.Port = val
 	case StretchFlag:
 		val, err := ValidateStretch(f.Value)
 		if err != nil {
@@ -106,7 +113,7 @@ func (cmd *SetImageCommand) Execute() error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal request body: %s", err)
 	}
-	url := fmt.Sprintf("http://127.0.0.1:%d/set-image", config.Port)
+	url := fmt.Sprintf("http://127.0.0.1:%d/set-image", Option(cmd.Port).UnwrapOr(config.Port))
 	resp, err := http.Post(url, "application/json", bytes.NewReader(reqBody))
 	if err != nil {
 		return err

--- a/docs/run_command_usage.md
+++ b/docs/run_command_usage.md
@@ -1,6 +1,5 @@
 # Table of Contents
 - [Overview](#tbg-run)
-- [Key events](#key-events)
 - [Executing with flags](#executing-with-flags)
 - [Usage](#usage)
     - [Normal Execution, key events, and path specific options](#normal-execution)
@@ -14,18 +13,12 @@
 settings from `.tbg.yml`. **tbg** will keep running, editing the
 `settings.json` of *Windows Terminal*, replacing the background image. The 
 background image is chosen randomly from the images under each path specified
-in `.tbg.yml`. Pressing `q` or `ctrl+c` will stop execution.
+in `.tbg.yml`.
 
 On initial execution of **tbg**, it will create a `.tbg.yml` in the same
 directory as the **tbg** executable if it does not exist already. **There can
 only be one `.tbg.yml`**. For more information, see documentation on
 [tbg.yml](https://github.com/saltkid/tbg/blob/main/docs/tbg.yml.md).
-
-# Key events
-**tbg** takes optional commands during execution:
-- `q`: quits
-- `c`: shows the available commands
-- `n`: goes to next image
 
 # Executing with flags
 #### Valid Flags: `--profile`, `--interval`, `--port`, `--alignment`, `--opacity`, `--stretch`
@@ -66,7 +59,10 @@ This just means that when we do `tbg run`, we want to change the background
 image of the **default** *Windows Terminal* profile every **30 minutes**. The
 image is chosen randomly from images under `/path/to/dir1` and `/path/to/dir2`.
 
-Now let's quit **tbg** by pressing `q` or `ctrl+c`.
+You can quit **tbg** by running:
+```bash
+tbg quit
+```
 
 ---
 ### Overriding `profile`, `port`, and `interval` fields
@@ -90,6 +86,11 @@ image of the `default` profile every 30 minutes, it will change the background
 image of the first profile under `list` field in `settings.json` every 5
 minutes instead. The server will run in port 8000 instead of what is defined
 in the config (9545)
+
+To quit, make sure to put the same port specified in `tbg run`:
+```bash
+tbg quit --port 8000
+```
 
 ---
 ### Overriding default values

--- a/flag_validators.go
+++ b/flag_validators.go
@@ -58,6 +58,9 @@ func ValidatePort(val *string) (*uint16, error) {
 	if valNum < 1 {
 		return nil, fmt.Errorf("invalid arg '%d' for --port: must be positive.", valNum)
 	}
+	if valNum > 65535 {
+		return nil, fmt.Errorf("invalid arg '%d' for --port: ports can only be up to 65535.", valNum)
+	}
 	ret := uint16(valNum)
 	return &ret, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,6 @@ module github.com/saltkid/tbg
 go 1.23.2
 
 require (
-	github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203
+	github.com/agnivade/levenshtein v1.2.1
 	gopkg.in/yaml.v3 v3.0.1
-)
-
-require (
-	github.com/agnivade/levenshtein v1.2.1 // indirect
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203 h1:XBBHcIb256gUJtLmY22n99HaZTz+r2Z51xUPi01m3wg=
-github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203/go.mod h1:E1jcSv8FaEny+OP/5k9UxZVw9YFWGj7eI4KR/iOBqCg=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
+github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
+github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7cNTs5R6Hk4V2lcmLz2NsG2VnInyNo=
+github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
closes #42 

---

## Changes
- removed listening to user input through keystrokes in tbg server
  - interaction with the server is now only through server commands or POST requests to API endpoints
- server commands (`next-image`, `set-image`, and `quit`) all take in `--port` flag now
- `run` command takes in `--port` flag to start a server in a specific port
- update docs to include example setup for pwsh and zsh