### PR TITLE
Feat/structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,14 @@
 - [Usage](#usage)
     - [Automatically change background image at a set interval](#automatically-change-background-image-at-a-set-interval)
     - [tbg server](#tbg-server)
+        - [Logging](#logging)
 - [Config](#config)
     - [Fields](#fields)
 - [Commands](#commands)
     - [Server Commands](#server-commands)
 - [Example Setup](#example-setup)
+    - [pwsh](#pwsh)
+    - [zsh (on wsl)](#zsh-on-wsl)
 - [Credits](#credits)
 
 ---
@@ -68,14 +71,22 @@ properties are:
 | opacity        | `1.0`          |
 | stretch        | `uniformToFill`|
 
-On initial execution of `tbg run`, it will create a [default `config.yml`](#config)
-in `$env:LOCALAPPDATA/tbg/config.yml`. You can edit this manually **or** use
-[tbg commands](#commands) to edit the fields with input validation.
+On initial execution of `tbg run`, it will create a [default
+`config.yml`](#config) in `$env:LOCALAPPDATA/tbg/config.yml`. You can edit this
+manually **or** use [tbg commands](#commands) to edit the fields with input
+validation.
 
 ## tbg server
 `tbg run` starts the **tbg** http server where POST requests can be made to
 trigger certain actions. These post requests can be made through [tbg server
-commands](#server-commands) for convenience
+commands](#server-commands) for convenience.
+
+### Logging
+A log file is in the same directory as the config file:
+`$env:LOCALAPPDATA/tbg/tbg.log`. It's in json so I recommend using
+[`jq`](https://jqlang.org/) to parse and get useful information out of it.
+
+See [logs](/docs/logs.md) for all log types and their structure.
 
 ---
 # Config
@@ -83,7 +94,8 @@ commands](#server-commands) for convenience
 the `settings.json` *Windows Terminal* uses. On initial execution of `tbg
 config`, a default config is created at that path. See example config at
 [samples](./samples/config.yml). A `schema.json` is also given for some basic
-autocomplete with [yaml-language-server](https://github.com/redhat-developer/yaml-language-server)
+autocomplete with
+[yaml-language-server](https://github.com/redhat-developer/yaml-language-server)
 
 ## Fields
 Although you can edit the fields in the config directly, it is recommended to
@@ -245,4 +257,5 @@ server instance too by specifing the same port used in starting it.
 # Credits
 - [Windows Terminal](https://github.com/microsoft/terminal)
 - [levenshtein](github.com/agnivade/levenshtein) for suggesting similar profile names
+- [lumberjack](https://github.com/natefinch/lumberjack) for easy rotating logs
 - [saltkid](https://github.com/saltkid)

--- a/command_run.go
+++ b/command_run.go
@@ -127,15 +127,16 @@ func (cmd *RunCommand) Execute() error {
 
 	config.Profile = Option(cmd.Profile).Or(config.Profile).val
 	config.Interval = Option(cmd.Interval).Or(config.Interval).val
+	config.Port = Option(cmd.Port).Or(config.Port).val
 	tbgState, err := NewTbgState(
 		config,
 		configPath,
-		Option(cmd.Alignment).UnwrapOr(DefaultAlignment),
-		Option(cmd.Stretch).UnwrapOr(DefaultStretch),
-		Option(cmd.Opacity).UnwrapOr(DefaultOpacity),
+		cmd.Alignment,
+		cmd.Opacity,
+		cmd.Stretch,
 	)
 	if err != nil {
 		return err
 	}
-	return tbgState.Start(cmd.Port)
+	return tbgState.Start()
 }

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -1,0 +1,143 @@
+# Table of Contents
+- [Log Types](#log-types)
+  1. [tbg initialization](#tbg-initialization)
+  2. [Starting tbg server](#starting-tbg-server)
+  3. [Edited Windows Terminal's `settings.json`](#edited-windows-terminals-settingsjson-to-change-the-background-image)
+  4. [Automatic image change at every n-interval](#automatic-image-change-at-every-n-interval)
+  5. [Changing image through `tbg next-image`](#changing-image-through-tbg-next-image-or-by-making-a-post-request-to-the)
+  6. [Setting a specific image as the background image through `tbg set-image`](#setting-a-specific-image-as-the-background-image-through-tbg-set-image-or)
+  7. [Quit server through `tbg quit`](#quit-server-through-tbg-quit-or-by-makign-a-post-request-to-the-quit)
+
+---
+# Log Types
+All logs have a `"time": "TIMESTAMP"` and `"level": "INFO"` so I will leave
+these two out.
+
+---
+### tbg initialization
+```json
+{
+  "msg": "Start tbg...Config used",
+  "paths": [
+    {
+      "opacity": 0.1,
+      "path": "/path/to/images/dir1"
+    },
+    {
+      "opacity": 0.5,
+      "path": "/path/to/images/dir2"
+      "stretch": "uniform"
+    },
+    {
+      "alignment": "right",
+      "opacity": 1.0,
+      "path": "/path/to/images/dir3"
+      "stretch": "fill"
+    }
+  ],
+  "interval": 20,
+  "port": 8000,
+  "profile": "default"
+}
+```
+
+---
+### Starting tbg server
+    - override-[alignment,opacity,stretch] is set through their respective
+    flags
+    - e.g. `tbg run --alignment center`
+```json
+{
+  "msg": "Starting server...",
+  "interval": 20,
+  "port": ":8000",
+  "profile": "default",
+  "override-alignment": "center",
+  "override-opacity": "no override",
+  "override-stretch": "no override"
+}
+```
+
+---
+### Edited Windows Terminal's `settings.json` to change the background image
+```json
+{
+  "msg": "Starting server...",
+  "image": "/path/to/image/file.png",
+  "profile": "default",
+  "alignment": "center",
+  "opacity": "0.25",
+  "stretch": "uniformToFill"
+}
+
+```
+
+---
+### Automatic image change at every n-interval
+```json
+{ "msg": "Image change tick" }
+```
+
+---
+### Changing image through `tbg next-image` or by making a POST request to the
+`next-image` endpoint
+    - there are multiple logs during this action
+```json
+{ "msg": "Recieved next-image request" }
+{ "msg": "next-image body decoded" }
+
+```
+_below may or may not be logged, depending on whether the option is set_
+```json
+{
+  "msg": "alignment",
+  "value": "center"
+}
+{
+  "msg": "opacity",
+  "value": "0.1"
+}
+{
+  "msg": "stretch",
+  "value": "fill"
+}
+```
+
+---
+### Setting a specific image as the background image through `tbg set-image` or
+by making a POST request to the `set-image` endpoint
+    - there are multiple logs during this action
+```json
+{ "msg": "Recieved set-image request" }
+{ "msg": "set-image body decoded" }
+{
+  "msg": "path",
+  "value": "/path/to/image/file.png"
+}
+```
+_below may or may not be logged, depending on whether the option is set_
+```json
+{
+  "msg": "alignment",
+  "value": "center"
+}
+{
+  "msg": "opacity",
+  "value": "0.1"
+}
+{
+  "msg": "stretch",
+  "value": "fill"
+}
+```
+
+---
+### Quit server through `tbg quit` or by makign a POST request to the `quit`
+endpoint
+```json
+{ "msg": "Recieved quit request" }
+```
+_below logs after cleaning up_
+```json
+{ "msg": "Goodbye!" }
+```

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.24.1
 
 require (
 	github.com/agnivade/levenshtein v1.2.1
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,7 @@ github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7c
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tbg.go
+++ b/tbg.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -113,12 +112,23 @@ func (tbg *TbgState) Start() error {
 	multiHandler := slog.NewJSONHandler(io.MultiWriter(logFile, os.Stdout), nil)
 	slog.SetDefault(slog.New(multiHandler))
 	slog.Info("Start tbg...Config used",
-		"paths", func() string {
-			var ret strings.Builder
-			for _, path := range tbg.Config.Paths {
-				ret.WriteString(path.String())
+		"paths", func() []map[string]any {
+			ret := make([]map[string]any, len(tbg.Config.Paths))
+			for i, path := range tbg.Config.Paths {
+				entry := make(map[string]any, 0)
+				entry["path"] = path.Path
+				if path.Alignment != nil {
+					entry["alignment"] = path.Alignment
+				}
+				if path.Opacity != nil {
+					entry["opacity"] = path.Opacity
+				}
+				if path.Stretch != nil {
+					entry["stretch"] = path.Stretch
+				}
+				ret[i] = entry
 			}
-			return ret.String()
+			return ret
 		}(),
 		"interval", tbg.Config.IntervalOrDefault(),
 		"port", tbg.Config.PortOrDefault(),


### PR DESCRIPTION
closes #48 

---

## New
1. log file, used slog for structured logging and lumberjack for rotating logs
    - log file is found at the same directory as the config: `$env:LOCALAPPDATA/tbg/tbg.log`
2. documentation on current logs at /docs/logs.yml
## Changes
- adding and removing paths now properly differentiates "no changes made" when trying to replace a field with the same value
- fix image not being identified as image file due to wrong path being passed (during tbg server running)